### PR TITLE
Add interactive roadmap page

### DIFF
--- a/roadmap/index.html
+++ b/roadmap/index.html
@@ -1,96 +1,302 @@
-diff --git a/index.html b/index.html
-index 7e0581ed885ccb06cdc19b47c275f2b2a1a4a00d..abcef1df360d9fa627c7d342961951b0fcb2d250 100644
---- a/index.html
-+++ b/index.html
-@@ -15,50 +15,51 @@
-   <meta property="og:description" content="A private, AI-powered life archive for capturing, organizing, and sharing your family’s story." />
-   <meta property="og:url" content="https://www.tryheirloomai.com/" />
-   <meta property="og:type" content="website" />
-   <meta property="og:image" content="https://www.tryheirloomai.com/logo.svg" />
- 
-   <!-- Twitter -->
-   <meta name="twitter:card" content="summary_large_image" />
-   <meta name="twitter:title" content="Heirloom — Preserve Every Memory. Share Every Story." />
-   <meta name="twitter:description" content="A private, AI-powered life archive for capturing, organizing, and sharing your family’s story." />
-   <meta name="twitter:image" content="https://www.tryheirloomai.com/logo.svg" />
- 
-   <!-- Tailwind CSS -->
-   <script src="https://cdn.tailwindcss.com"></script>
- 
-   <!-- Plausible Analytics -->
-   <script defer data-domain="tryheirloomai.com" src="https://plausible.io/js/script.js"></script>
- </head>
- <body class="bg-[#fafaf7] text-slate-900 font-sans">
-   <header class="max-w-[60rem] mx-auto flex items-center justify-between py-6 px-4">
-     <a href="/" class="flex items-center">
-       <img src="/logo.svg" alt="Heirloom logo" class="h-8" />
-     </a>
-     <nav class="flex items-center gap-6 text-sm">
-       <a href="/" class="hover:underline">Home</a>
-       <a href="/demo/" class="hover:underline">Demo</a>
-+      <a href="/roadmap/" class="hover:underline">Roadmap</a>
-       <a href="#waitlist" class="hover:underline">Waitlist</a>
-     </nav>
-   </header>
- 
-   <main class="px-4">
-     <!-- Hero -->
-     <section class="max-w-[60rem] mx-auto text-center py-20">
-       <img src="/logo.svg" alt="Heirloom logo" class="mx-auto h-32" />
-       <h1 class="mt-8 text-4xl md:text-5xl font-serif font-bold text-[#3B7A57]">Preserve Every Memory. Share Every Story.</h1>
-       <p class="mt-4 text-lg text-slate-700">Your family's private archive to capture, rediscover, and share a life of moments.</p>
-       <div id="waitlist" class="mt-10 max-w-md mx-auto bg-white rounded-xl shadow-sm p-6">
-         <h2 class="font-serif text-xl font-bold">Join the waitlist</h2>
-         <p class="mt-2 text-slate-600 text-sm">Get early access and product updates.</p>
-         <div class="mt-4">
-           <!-- BEEHIIV_EMBED -->
-           <a href="#" class="block w-full rounded-lg bg-gradient-to-r from-[#3B7A57] to-[#f97316] px-5 py-3 text-white font-semibold">Join the Waitlist</a>
-         </div>
-       </div>
-     </section>
- 
-     <!-- Features -->
-     <section class="max-w-[60rem] mx-auto py-16">
-       <h2 class="text-3xl font-serif font-bold text-center">Features</h2>
-       <div class="mt-8 grid gap-8 md:grid-cols-3 text-slate-700">
-         <div class="text-center">
-diff --git a/index.html b/index.html
-index 7e0581ed885ccb06cdc19b47c275f2b2a1a4a00d..abcef1df360d9fa627c7d342961951b0fcb2d250 100644
---- a/index.html
-+++ b/index.html
-@@ -77,34 +78,35 @@
-           <p class="mt-2 text-sm">Let AI weave your memories into shareable narratives.</p>
-         </div>
-       </div>
-     </section>
- 
-     <!-- Values -->
-     <section class="max-w-[60rem] mx-auto py-16">
-       <h2 class="text-3xl font-serif font-bold text-center">Values</h2>
-       <div class="mt-8 grid gap-8 md:grid-cols-2">
-         <div class="bg-white rounded-xl p-6 shadow-sm text-center md:text-left">
-           <h3 class="font-serif font-semibold text-lg">Privacy-First</h3>
-           <p class="mt-2 text-slate-700 text-sm">Your memories stay yours with encryption and sharing controls.</p>
-         </div>
-         <div class="bg-white rounded-xl p-6 shadow-sm text-center md:text-left">
-           <h3 class="font-serif font-semibold text-lg">Family-First</h3>
-           <p class="mt-2 text-slate-700 text-sm">Built to preserve stories for generations to come.</p>
-         </div>
-       </div>
-     </section>
-   </main>
- 
-   <footer class="max-w-[60rem] mx-auto px-4 py-10 text-sm text-slate-600 flex flex-col sm:flex-row items-center justify-between gap-4">
-     <p>© <span id="y"></span> Heirloom</p>
-     <div class="flex gap-5">
-       <a href="/demo/" class="hover:underline">Demo</a>
-+      <a href="/roadmap/" class="hover:underline">Roadmap</a>
-       <a href="/thanks" class="hover:underline">Thanks</a>
-     </div>
-   </footer>
- 
-   <script>
-     document.getElementById('y').textContent = new Date().getFullYear();
-   </script>
- </body>
- </html>
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Heirloom Roadmap — The Next 12 Months</title>
+  <meta name="description" content="A look at what's ahead for Heirloom over the next year." />
+
+  <!-- Favicon -->
+  <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+  <link rel="canonical" href="https://www.tryheirloomai.com/roadmap/" />
+
+  <!-- Open Graph -->
+  <meta property="og:title" content="Heirloom Roadmap — The Next 12 Months" />
+  <meta property="og:description" content="A look at what's ahead for Heirloom over the next year." />
+  <meta property="og:url" content="https://www.tryheirloomai.com/roadmap/" />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://www.tryheirloomai.com/logo.svg" />
+
+  <!-- Twitter -->
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Heirloom Roadmap — The Next 12 Months" />
+  <meta name="twitter:description" content="A look at what's ahead for Heirloom over the next year." />
+  <meta name="twitter:image" content="https://www.tryheirloomai.com/logo.svg" />
+
+  <!-- Tailwind CSS -->
+  <script src="https://cdn.tailwindcss.com"></script>
+
+  <!-- Plausible Analytics -->
+  <script defer data-domain="tryheirloomai.com" src="https://plausible.io/js/script.js"></script>
+</head>
+<body class="bg-[#fafaf7] text-slate-900 font-sans">
+  <main class="max-w-[60rem] mx-auto px-4 py-10">
+    <a href="/" class="text-sm text-orange-600 hover:underline">&larr; Back to Home</a>
+    <h1 class="mt-4 text-3xl font-serif font-bold text-[#3B7A57]">Roadmap</h1>
+    <p class="mt-1 text-sm text-slate-600">Last updated: <span>2025-09-01</span></p>
+
+    <div class="mt-6">
+      <div class="w-full bg-slate-200 h-2 rounded-full">
+        <div id="progress-bar" class="h-2 rounded-full bg-gradient-to-r from-[#f97316] to-[#fdba74]" style="width:0%"></div>
+      </div>
+      <p class="mt-1 text-sm text-slate-600"><span id="progress-text">0%</span> complete</p>
+    </div>
+
+    <div class="mt-6 flex gap-3">
+      <button id="btn-now" class="px-3 py-1 rounded border border-slate-300 bg-white text-sm">Jump to Now</button>
+      <button id="btn-copy" class="px-3 py-1 rounded border border-slate-300 bg-white text-sm">Copy Roadmap Link</button>
+    </div>
+
+    <!-- Timeline -->
+    <div class="mt-12">
+      <!-- Mobile -->
+      <div id="timeline-mobile" class="md:hidden relative h-[900px]">
+        <div class="absolute left-1/2 top-0 bottom-0 w-1 -translate-x-1/2 bg-gradient-to-b from-[#fdba74] to-[#f97316]"></div>
+        <div id="mobile-months" class="flex flex-col justify-between h-full"></div>
+        <div id="mobile-milestones" class="absolute inset-0"></div>
+      </div>
+      <!-- Desktop -->
+      <div id="timeline-desktop" class="hidden md:block relative h-[420px]">
+        <div class="absolute top-1/2 left-0 right-0 h-1 -translate-y-1/2 bg-gradient-to-r from-[#fdba74] to-[#f97316]"></div>
+        <div id="desktop-months" class="flex justify-between w-full"></div>
+        <div id="desktop-milestones" class="absolute inset-0"></div>
+      </div>
+    </div>
+
+    <!-- Legend -->
+    <div class="mt-12">
+      <h2 class="font-serif font-bold text-xl mb-4">Legend</h2>
+      <div class="flex flex-wrap gap-4 text-sm">
+        <div class="flex items-center gap-2"><span class="px-2 py-0.5 rounded-full bg-green-100 text-green-700 text-xs">Completed</span> Completed</div>
+        <div class="flex items-center gap-2"><span class="px-2 py-0.5 rounded-full bg-indigo-100 text-indigo-700 text-xs">In progress</span> In progress</div>
+        <div class="flex items-center gap-2"><span class="px-2 py-0.5 rounded-full bg-orange-100 text-orange-700 text-xs">Now</span> Now</div>
+        <div class="flex items-center gap-2"><span class="px-2 py-0.5 rounded-full bg-slate-100 text-slate-700 text-xs">Planned</span> Planned</div>
+      </div>
+    </div>
+
+    <p class="mt-8 text-sm text-slate-600">Roadmap is directional and may change.</p>
+  </main>
+
+  <script>
+    const MILESTONES = [
+      {
+        id: "funding",
+        title: "Secure funding",
+        timeframe: "Months 1–2",
+        status: "in_progress",
+        now: true,
+        description: "Close pre-seed, finalize entity, basic runway.",
+        link: null
+      },
+      {
+        id: "foundations",
+        title: "Foundations & infra",
+        timeframe: "Months 1–3",
+        status: "in_progress",
+        now: false,
+        description: "Auth, storage, environments, observability, CI/CD.",
+        link: null
+      },
+      {
+        id: "alpha",
+        title: "Alpha: capture & recall",
+        timeframe: "Months 2–4",
+        status: "planned",
+        now: false,
+        description: "Journal, photo upload, search, smart tags.",
+        link: null
+      },
+      {
+        id: "import",
+        title: "Data import tools",
+        timeframe: "Months 3–5",
+        status: "planned",
+        now: false,
+        description: "Bulk import from Photos/Drive; de-dupe; EXIF/time alignment.",
+        link: null
+      },
+      {
+        id: "beta",
+        title: "Private beta cohort",
+        timeframe: "Months 4–6",
+        status: "planned",
+        now: false,
+        description: "50–100 users; feedback loops; basic analytics.",
+        link: null
+      },
+      {
+        id: "narrative",
+        title: "Narrative generation v1",
+        timeframe: "Months 5–7",
+        status: "planned",
+        now: false,
+        description: "Multi-chapter stories w/ citations to user data.",
+        link: null
+      },
+      {
+        id: "sharing",
+        title: "Family sharing & roles",
+        timeframe: "Months 6–8",
+        status: "planned",
+        now: false,
+        description: "Circles, invites, approvals, shared albums/timelines.",
+        link: null
+      },
+      {
+        id: "mobile",
+        title: "Mobile apps (preview)",
+        timeframe: "Months 7–9",
+        status: "planned",
+        now: false,
+        description: "iOS/Android capture, offline drafts, background uploads.",
+        link: null
+      },
+      {
+        id: "privacy",
+        title: "Privacy: E2EE vault",
+        timeframe: "Months 8–10",
+        status: "planned",
+        now: false,
+        description: "End-to-end encryption for designated collections.",
+        link: null
+      },
+      {
+        id: "print",
+        title: "Print & export",
+        timeframe: "Months 9–10",
+        status: "planned",
+        now: false,
+        description: "Photo books, PDFs, JSON export.",
+        link: null
+      },
+      {
+        id: "public_beta",
+        title: "Public beta",
+        timeframe: "Months 10–11",
+        status: "planned",
+        now: false,
+        description: "Waitlist open, pricing preview, onboarding flows.",
+        link: null
+      },
+      {
+        id: "launch",
+        title: "v1 Launch",
+        timeframe: "Month 12",
+        status: "planned",
+        now: false,
+        description: "Subscriptions, partnerships, support docs.",
+        link: null
+      }
+    ];
+
+    const STATUS_COLORS = {
+      planned: 'bg-slate-100 text-slate-700',
+      in_progress: 'bg-indigo-100 text-indigo-700',
+      completed: 'bg-green-100 text-green-700'
+    };
+    const STATUS_TEXT = {
+      planned: 'Planned',
+      in_progress: 'In progress',
+      completed: 'Completed'
+    };
+
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    function computeProgress(items) {
+      const weights = { planned: 0, in_progress: 0.5, completed: 1 };
+      const avg = items.reduce((sum, m) => sum + (weights[m.status] || 0), 0) / items.length;
+      return Math.round(avg * 100);
+    }
+
+    function badgeHTML(m) {
+      const statusBadge = `<span class="px-2 py-0.5 rounded-full text-xs ${STATUS_COLORS[m.status]}">${STATUS_TEXT[m.status]}</span>`;
+      const nowBadge = m.now ? `<span class="px-2 py-0.5 rounded-full text-xs bg-orange-100 text-orange-700">Now</span>` : '';
+      return statusBadge + nowBadge;
+    }
+
+    function renderTimeline() {
+      const mobileMonths = document.getElementById('mobile-months');
+      const desktopMonths = document.getElementById('desktop-months');
+      for (let i = 1; i <= 12; i++) {
+        const mm = document.createElement('div');
+        mm.className = 'flex items-center';
+        mm.innerHTML = `<div class="w-3 h-3 rounded-full bg-white border-2 border-orange-300"></div><span class="ml-2 text-xs">M${i}</span>`;
+        mobileMonths.appendChild(mm);
+        const dm = document.createElement('div');
+        dm.className = 'flex flex-col items-center';
+        dm.innerHTML = `<div class="w-3 h-3 rounded-full bg-white border-2 border-orange-300"></div><span class="mt-2 text-xs">M${i}</span>`;
+        desktopMonths.appendChild(dm);
+      }
+
+      const mobileMilestones = document.getElementById('mobile-milestones');
+      const desktopMilestones = document.getElementById('desktop-milestones');
+
+      MILESTONES.forEach(m => {
+        const match = m.timeframe.match(/(Month|Months)\s*(\d+)/);
+        const start = match ? parseInt(match[2], 10) : 1;
+        const percent = (start - 1) / 11 * 100;
+        const linkHTML = m.link ? `<a href="${m.link}" class="text-orange-600 hover:underline text-sm mt-2">Learn more →</a>` : '';
+        const cardHTML = `<div class="rounded-lg bg-white shadow-sm p-4 w-64">
+            ${badgeHTML(m)}
+            <h3 class="mt-2 font-serif font-semibold">${m.title}</h3>
+            <p class="text-xs text-slate-600">${m.timeframe}</p>
+            <p class="mt-2 text-sm text-slate-700">${m.description}</p>
+            ${linkHTML}
+          </div>`;
+
+        const mobWrap = document.createElement('div');
+        mobWrap.className = 'absolute flex items-center';
+        mobWrap.style.top = `calc(${percent}% - 1rem)`;
+        mobWrap.style.left = '55%';
+        mobWrap.innerHTML = `<div class="w-2 h-2 rounded-full bg-orange-300 mr-3"></div>${cardHTML}`;
+        mobileMilestones.appendChild(mobWrap);
+
+        const deskWrap = document.createElement('div');
+        deskWrap.className = 'absolute flex flex-col items-center';
+        deskWrap.style.left = `calc(${percent}% - 1rem)`;
+        deskWrap.style.top = '-1rem';
+        deskWrap.innerHTML = `<div class="w-2 h-2 rounded-full bg-orange-300 mb-3"></div>${cardHTML}`;
+        desktopMilestones.appendChild(deskWrap);
+      });
+
+      const nowMilestone = MILESTONES.find(m => m.now);
+      if (nowMilestone) {
+        const match = nowMilestone.timeframe.match(/(Month|Months)\s*(\d+)/);
+        const start = match ? parseInt(match[2], 10) : 1;
+        const percent = (start - 1) / 11 * 100;
+
+        const nowMob = document.createElement('div');
+        nowMob.className = 'absolute left-1/2 -translate-x-1/2';
+        nowMob.style.top = `calc(${percent}% - 0.5rem)`;
+        nowMob.innerHTML = `<div class="flex items-center" data-now-marker="true"><div class="w-3 h-3 rounded-full bg-orange-500 ${prefersReducedMotion ? '' : 'animate-pulse'}"></div><span class="ml-2 text-xs text-orange-700">Now</span></div>`;
+        mobileMilestones.appendChild(nowMob);
+
+        const nowDesk = document.createElement('div');
+        nowDesk.className = 'absolute top-1/2 -translate-y-1/2';
+        nowDesk.style.left = `calc(${percent}% - 0.5rem)`;
+        nowDesk.innerHTML = `<div class="flex flex-col items-center" data-now-marker="true"><div class="w-3 h-3 rounded-full bg-orange-500 ${prefersReducedMotion ? '' : 'animate-pulse'}"></div><span class="mt-1 text-xs text-orange-700">Now</span></div>`;
+        desktopMilestones.appendChild(nowDesk);
+      }
+
+      const progress = computeProgress(MILESTONES);
+      document.getElementById('progress-bar').style.width = progress + '%';
+      document.getElementById('progress-text').textContent = progress + '%';
+    }
+
+    function scrollToNow() {
+      const el = document.querySelector('[data-now-marker="true"]');
+      if (el) {
+        el.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth', block: 'center', inline: 'center' });
+      }
+    }
+
+    document.getElementById('btn-now').addEventListener('click', scrollToNow);
+    document.getElementById('btn-copy').addEventListener('click', () => {
+      navigator.clipboard.writeText(window.location.href);
+    });
+
+    renderTimeline();
+    window.addEventListener('load', scrollToNow);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- introduce `/roadmap/` page with Tailwind-powered timeline, milestone cards, and progress bar
- smooth-scroll “Jump to Now” and clipboard copy buttons for quick navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b5abbfb5fc832e9695ad604cc497e8