### PR TITLE
feat(site): add About Heirloom page and refine landing embed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changelog
+
+- remove `About` and `Investor Info` links from all headers and footers
+- add `/about.html` with company background and vision
+- restyle Beehiiv embed on landing page; center and remove card UI
+- add `meta name="robots" content="noindex, nofollow"` to `investorinfo` pages

--- a/about.html
+++ b/about.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About Heirloom</title>
+  <meta name="description" content="Heirloom's origin story, features, and vision."/>
+  <link rel="canonical" href="https://www.tryheirloomai.com/about.html">
+  <meta property="og:title" content="About Heirloom">
+  <meta property="og:description" content="Heirloom's origin story, features, and vision.">
+  <meta property="og:image" content="/assets/hero.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/css/styles.css">
+  <script defer src="/js/main.js"></script>
+</head>
+<body>
+<header>
+  <div class="header-inner">
+    <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
+    <button class="nav-toggle" aria-label="Menu">☰</button>
+    <nav>
+      <a href="/roadmap.html">Roadmap</a>
+      <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <article style="max-width:800px; margin:2rem auto; padding:0 1rem;">
+    <h1>About Heirloom</h1>
+    <section>
+      <h2>The Spark</h2>
+      <p>Heirloom began with a simple, stubborn question: why do our best memories live in a thousand places and still slip away? Phones get replaced, platforms change, and family stories scatter. We built Heirloom to pull the threads together—your photos, videos, notes, voice logs, little moments—and weave them into something that lasts.</p>
+    </section>
+    <section>
+      <h2>What Heirloom Does Today</h2>
+      <ul>
+        <li>Capture the everyday: quick journals, voice notes, photos, and milestones that slot right into a private timeline.</li>
+        <li>Ingest the past: pull in old albums and files, keep originals organized, and de-duplicate safely.</li>
+        <li>Recall with context: find moments by people, places, dates, or even vibes—“that rainy day in June with the dogs.”</li>
+        <li>Tell the story: draft multi-chapter life stories from your timeline, with citations back to your own memories.</li>
+        <li>Share, selectively: invite family into specific albums or chapters—private by default, on your terms.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>What’s Next</h2>
+      <ul>
+        <li>Genealogy mode: understand relationships across generations, blending family trees with real memories.</li>
+        <li>Talk to Me: ask natural questions about your life (“When did we visit Acadia?”), and get answers grounded in your data.</li>
+        <li>Posthumous releases: schedule messages or chapters to be shared later, with proper controls and consent.</li>
+        <li>Deeper search: richer queries across emotions, locations, and recurring rituals.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>The Long View</h2>
+      <ul>
+        <li>Local-first hardware: a dedicated HeirloomOS device for full offline operation, GPU-powered recall, and long-term archival at home.</li>
+        <li>Seamless migration: start in the web app, move to hardware when you’re ready—same account, same memories, no lock-in.</li>
+        <li>Privacy as a principle: client-side encryption options, no ad targeting, no data resale. Your stories stay yours.</li>
+      </ul>
+    </section>
+    <section>
+      <h2>Why It Matters</h2>
+      <p>Memories are more than files; they’re the connective tissue of a family. Heirloom’s job is to protect them, organize them, and help them speak.</p>
+    </section>
+  </article>
+</main>
+<footer>
+  <p>© Heirloom</p>
+  <nav>
+    <a href="/roadmap.html">Roadmap</a> •
+    <a href="/privacy.html">Privacy</a> •
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
+  </nav>
+</footer>
+</body>
+</html>

--- a/css/styles.css
+++ b/css/styles.css
@@ -46,7 +46,6 @@ nav{display:flex;gap:1rem;align-items:center;}
 .hero h1{font-size:clamp(2rem,5vw,3rem);margin-top:1rem;}
 .hero p{color:var(--muted);max-width:60ch;margin:.5rem auto 2rem;}
 .links a{color:var(--muted);font-size:.875rem;}
-.beehiiv-card{max-width:700px;margin:0 auto;padding:1rem;background:var(--bg-elev);border-radius:18px;}
 footer{margin-top:auto;padding:2rem 1rem;font-size:.875rem;text-align:center;color:var(--muted);}
 footer a{color:var(--muted);}
 .timeline{position:relative;margin:2rem auto;padding-left:2rem;max-width:var(--max-width);}
@@ -64,3 +63,7 @@ footer a{color:var(--muted);}
 .chat-input{display:flex;gap:.5rem;padding:1rem;background:var(--bg);border-top:1px solid var(--border);}
 .chat-input input{flex:1;border:1px solid var(--border);border-radius:12px;padding:.5rem;}
 @media (prefers-reduced-motion: reduce){*{transition:none!important;animation-duration:.01ms!important;}}
+
+.bhv-wrap{max-width:720px;margin:0 auto;padding:0;}
+.beehiiv-embed{width:100%!important;max-width:100%!important;height:415px;border:0;display:block;}
+@media (max-width:480px){.beehiiv-embed{height:460px;}}

--- a/index.html
+++ b/index.html
@@ -21,8 +21,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -32,19 +30,17 @@
     <img src="/assets/logo.svg" alt="Heirloom logo large">
     <h1>Heirloom — Your Family’s Living Memory</h1>
     <p>Capture life, remember everything, and pass it on—private by design.</p>
-    <button data-scroll href="#waitlist">Join the Waitlist</button>
     <div class="links" style="margin-top:1rem; display:flex; gap:1rem; justify-content:center; flex-wrap:wrap;">
-      <a href="/investorinfo/team.html">About the Team</a>
+      <a href="/about.html">About Heirloom</a>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/">Investor Info</a>
     </div>
   </section>
-  <section id="waitlist" class="beehiiv-card">
-<script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
-<iframe src="https://subscribe-forms.beehiiv.com/7e97f2c9-aee6-4586-9d07-0ca2538b53ad"
-  class="beehiiv-embed" data-test-id="beehiiv-embed" frameborder="0" scrolling="no"
-  style="width: 660px; height: 415px; margin: 0; border-radius: 0px 0px 0px 0px !important; background-color: transparent; box-shadow: 0 0 #0000; max-width: 100%;">
-</iframe>
+  <section id="waitlist">
+    <script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
+    <div class="bhv-wrap">
+      <iframe src="https://subscribe-forms.beehiiv.com/7e97f2c9-aee6-4586-9d07-0ca2538b53ad"
+        class="beehiiv-embed" data-test-id="beehiiv-embed" frameborder="0" scrolling="no"></iframe>
+    </div>
   </section>
 </main>
 <footer>
@@ -52,8 +48,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/investorinfo/deck.html
+++ b/investorinfo/deck.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Pitch deck viewer.">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/styles.css">
   <script defer src="/js/main.js"></script>
@@ -21,8 +22,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -42,8 +41,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/investorinfo/demo.html
+++ b/investorinfo/demo.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Chat-style demo.">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/styles.css">
   <script defer src="/js/main.js"></script>
@@ -37,8 +38,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -57,8 +56,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/investorinfo/full-pitch.html
+++ b/investorinfo/full-pitch.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Full narrative for Heirloom.">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/styles.css">
   <script defer src="/js/main.js"></script>
@@ -21,8 +22,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -70,8 +69,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/investorinfo/index.html
+++ b/investorinfo/index.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Investor materials, timelines, and demo.">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/styles.css">
   <script defer src="/js/main.js"></script>
@@ -21,8 +22,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -45,8 +44,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/investorinfo/one-pager.html
+++ b/investorinfo/one-pager.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Heirloom — The Family Memory OS">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/styles.css">
   <script defer src="/js/main.js"></script>
@@ -21,8 +22,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -62,8 +61,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/investorinfo/team.html
+++ b/investorinfo/team.html
@@ -10,6 +10,7 @@
   <meta property="og:description" content="Meet the team.">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
+  <meta name="robots" content="noindex, nofollow">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="/css/styles.css">
   <script defer src="/js/main.js"></script>
@@ -21,8 +22,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -60,8 +59,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/privacy.html
+++ b/privacy.html
@@ -21,8 +21,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -38,8 +36,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/roadmap.html
+++ b/roadmap.html
@@ -21,8 +21,6 @@
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
       <a href="/roadmap.html">Roadmap</a>
-      <a href="/investorinfo/team.html">About</a>
-      <a href="/investorinfo/">Investor Info</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
@@ -74,8 +72,7 @@
   <nav>
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
-    <a href="mailto:hello@tryheirloomai.com">Contact</a> •
-    <a href="/investorinfo/">Investor Info</a>
+    <a href="mailto:hello@tryheirloomai.com">Contact</a>
   </nav>
 </footer>
 </body>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -11,34 +11,9 @@
     <priority>0.8</priority>
   </url>
   <url>
-    <loc>https://www.tryheirloomai.com/investorinfo/</loc>
-    <changefreq>monthly</changefreq>
-    <priority>0.5</priority>
-  </url>
-  <url>
-    <loc>https://www.tryheirloomai.com/investorinfo/one-pager.html</loc>
+    <loc>https://www.tryheirloomai.com/about.html</loc>
     <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
-  </url>
-  <url>
-    <loc>https://www.tryheirloomai.com/investorinfo/full-pitch.html</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
-  </url>
-  <url>
-    <loc>https://www.tryheirloomai.com/investorinfo/deck.html</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
-  </url>
-  <url>
-    <loc>https://www.tryheirloomai.com/investorinfo/demo.html</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
-  </url>
-  <url>
-    <loc>https://www.tryheirloomai.com/investorinfo/team.html</loc>
-    <changefreq>yearly</changefreq>
-    <priority>0.4</priority>
+    <priority>0.6</priority>
   </url>
   <url>
     <loc>https://www.tryheirloomai.com/privacy.html</loc>


### PR DESCRIPTION
## Summary
- add `/about.html` with origin story, features and vision
- drop About & Investor Info links sitewide and link to About Heirloom from landing
- center Beehiiv embed without card styling; remove waitlist CTA
- add `noindex, nofollow` robots meta to investor pages and remove from sitemap

## Testing
- `npx --yes html-validate index.html about.html roadmap.html privacy.html investorinfo/*.html` *(fails: Inline style is not allowed)*

------
https://chatgpt.com/codex/tasks/task_e_68b8f0ed3d00832ebf3526846ae6a016