### PR TITLE
Add tiles for About and Roadmap on home page

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -55,6 +55,11 @@ footer a{color:var(--muted);}
 .status{display:inline-block;padding:.125rem .5rem;border-radius:8px;font-size:.75rem;background:var(--border);color:var(--ink);margin-bottom:.5rem;}
 @media(max-width:600px){.timeline{padding-left:1rem;}.milestone{padding-left:1rem;}.milestone::before{left:-.75rem;}}
 .grid{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));}
+.tiles{max-width:var(--max-width);margin:2rem auto;padding:0 1rem;}
+.tile{display:block;padding:1.5rem;border:1px solid var(--border);border-radius:12px;background:var(--bg-elev);text-align:center;transition:background .2s,border-color .2s;}
+.tile h2{margin-bottom:.5rem;}
+.tile p{color:var(--muted);font-size:.875rem;}
+.tile:hover{background:var(--bg);border-color:var(--brand);}
 .chat{max-width:800px;margin:2rem auto;display:flex;flex-direction:column;height:80vh;background:var(--bg-elev);border-radius:18px;overflow:hidden;}
 .chat-messages{flex:1;padding:1rem;overflow-y:auto;background:var(--bg-elev);background-image:url('/assets/logo.svg');background-repeat:no-repeat;background-position:center;background-size:200px;background-attachment:fixed;}
 .message{margin-bottom:1rem;max-width:75%;padding:.5rem 1rem;border-radius:12px;}

--- a/index.html
+++ b/index.html
@@ -39,9 +39,17 @@
     <img src="/assets/logo.svg" alt="Heirloom logo large">
     <h1>Heirloom — Your Family’s Living Memory</h1>
     <p>Capture life, remember everything, and pass it on—private by design.</p>
-    <div class="links" style="margin-top:1rem; display:flex; gap:1rem; justify-content:center; flex-wrap:wrap;">
-      <a href="/about.html">About Heirloom</a>
-      <a href="/roadmap.html">Roadmap</a>
+  </section>
+  <section class="tiles">
+    <div class="grid">
+      <a class="tile" href="/about.html">
+        <h2>About Heirloom</h2>
+        <p>Learn the story and mission behind the app.</p>
+      </a>
+      <a class="tile" href="/roadmap.html">
+        <h2>Roadmap</h2>
+        <p>See what’s coming next for Heirloom.</p>
+      </a>
     </div>
   </section>
   <section id="waitlist">


### PR DESCRIPTION
## Summary
- Replace simple links on home page with styled tiles for "About Heirloom" and "Roadmap"
- Add CSS for tile layout and hover styles

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb18c5a844832e924a528304bae14a