### PR TITLE
Add full privacy policy page

### DIFF
--- a/privacy.html
+++ b/privacy.html
@@ -7,20 +7,14 @@
     window.dataLayer = window.dataLayer || [];
     function gtag(){dataLayer.push(arguments);}
     gtag('js', new Date());
-
     gtag('config', 'G-SNYJSRN7TW');
   </script>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>Privacy Policy — Heirloom</title>
-  <meta name="description" content="Privacy policy placeholder."/>
-  <link rel="canonical" href="https://www.tryheirloomai.com/privacy.html">
-  <meta property="og:title" content="Privacy Policy — Heirloom">
-  <meta property="og:description" content="Privacy policy placeholder.">
-  <meta property="og:image" content="/assets/hero.jpg">
-  <meta name="twitter:card" content="summary_large_image">
-  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
-  <link rel="stylesheet" href="/css/styles.css">
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Privacy Policy | Heirloom</title>
+  <meta name="description" content="Our commitment to protecting your privacy and data security." />
+  <link rel="canonical" href="/privacy.html" />
+  <link rel="stylesheet" href="/css/styles.css" />
   <script defer src="/js/main.js"></script>
 </head>
 <body>
@@ -35,12 +29,48 @@
     </nav>
   </div>
 </header>
-<main>
-  <article style="max-width:800px; margin:2rem auto; padding:0 1rem;">
-    <h1>Privacy Policy</h1>
-    <p>This is a placeholder privacy policy.</p>
-  </article>
+
+<main class="container">
+  <h1>Privacy Policy</h1>
+  <p>Effective Date: January 1, 2025</p>
+
+  <h2>1. Introduction</h2>
+  <p>Heirloom Inc. (“Heirloom,” “we,” “us,” or “our”) respects your privacy. This Privacy Policy explains how we collect, use, and safeguard information when you use our services. By accessing or using our website or applications, you agree to this policy.</p>
+
+  <h2>2. Information We Collect</h2>
+  <p>We may collect information that you provide directly to us, such as your name, email address, or other contact details. We also collect technical data automatically, including IP addresses, browser types, and usage information to help us improve our services.</p>
+
+  <h2>3. How We Use Information</h2>
+  <p>We use the information we collect to operate, maintain, and improve our services; to communicate with you; and to comply with legal obligations. We may also use aggregated or anonymized data for analytics and service enhancement.</p>
+
+  <h2>4. Cookies &amp; Tracking</h2>
+  <p>We use cookies and similar tracking technologies to personalize your experience, analyze usage, and deliver relevant content. You can adjust your browser settings to refuse cookies, but this may limit certain features.</p>
+
+  <h2>5. Data Sharing &amp; Disclosure</h2>
+  <p>We do not sell your personal information. We may share information with trusted service providers who assist us in operating our services, subject to confidentiality obligations. We may also disclose information if required by law or to protect our rights.</p>
+
+  <h2>6. Data Security</h2>
+  <p>We implement reasonable technical and organizational measures to protect your information from unauthorized access, loss, or misuse. However, no system can be completely secure, and we cannot guarantee absolute security.</p>
+
+  <h2>7. Your Rights</h2>
+  <p>You may request access to, correction of, or deletion of your personal information. To exercise these rights, contact us using the information below. We will respond in accordance with applicable laws.</p>
+
+  <h2>8. Children’s Privacy</h2>
+  <p>Our services are not directed to individuals under 13, and we do not knowingly collect personal information from children. If we learn that a child has provided us with personal information, we will take steps to delete such information.</p>
+
+  <h2>9. Changes to This Policy</h2>
+  <p>We may update this Privacy Policy from time to time. When we do, we will revise the effective date above and post the updated policy on this page. Your continued use of the services after changes are posted constitutes your acceptance of the revised policy.</p>
+
+  <h2>10. Contact Information</h2>
+  <p>If you have any questions or concerns about this Privacy Policy or our data practices, please contact us:</p>
+  <address>
+    Heirloom Inc.<br />
+    521 Shaker Rd.<br />
+    Canterbury, NH 03224<br />
+    <a href="mailto:TryHeirloomAi@gmail.com">TryHeirloomAi@gmail.com</a>
+  </address>
 </main>
+
 <footer>
   <p>© Heirloom</p>
   <nav>


### PR DESCRIPTION
## Summary
- replace placeholder privacy page with fully detailed policy using site header, footer, and styles
- document information collection, usage, cookies, data sharing, security, user rights, children's privacy, policy changes, and contact info

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb873ee534832e82448269b61eb1e6