### PR TITLE
Remove roadmap and contact links from header

### DIFF
--- a/about.html
+++ b/about.html
@@ -29,8 +29,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/contact.html
+++ b/contact.html
@@ -24,8 +24,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/index.html
+++ b/index.html
@@ -29,8 +29,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/investorinfo/deck.html
+++ b/investorinfo/deck.html
@@ -30,8 +30,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/investorinfo/demo.html
+++ b/investorinfo/demo.html
@@ -46,8 +46,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/investorinfo/full-pitch.html
+++ b/investorinfo/full-pitch.html
@@ -30,8 +30,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/investorinfo/index.html
+++ b/investorinfo/index.html
@@ -30,8 +30,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/investorinfo/one-pager.html
+++ b/investorinfo/one-pager.html
@@ -30,8 +30,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/investorinfo/team.html
+++ b/investorinfo/team.html
@@ -30,8 +30,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/privacy.html
+++ b/privacy.html
@@ -23,8 +23,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>

--- a/roadmap.html
+++ b/roadmap.html
@@ -29,8 +29,6 @@
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
     <button class="nav-toggle" aria-label="Menu">☰</button>
     <nav>
-      <a href="/roadmap.html">Roadmap</a>
-      <a href="/contact.html">Contact</a>
       <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>


### PR DESCRIPTION
## Summary
- Remove roadmap and contact navigation links from header across all pages

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb8e338288832e8a131aef95f2110c