### PR TITLE
Refresh About page with editorial layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <!-- Google tag (gtag.js) -->
@@ -13,7 +13,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>About Heirloom</title>
-  <meta name="description" content="Heirloom's origin story, features, and vision."/>
+  <meta name="description" content="Heirloom's origin story, features, and vision.">
   <link rel="canonical" href="https://www.tryheirloomai.com/about.html">
   <meta property="og:title" content="About Heirloom">
   <meta property="og:description" content="Heirloom's origin story, features, and vision.">
@@ -27,56 +27,155 @@
 <header>
   <div class="header-inner">
     <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
-    <button class="nav-toggle" aria-label="Menu">☰</button>
-    <nav>
-      <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
+    <button class="nav-toggle" type="button" aria-label="Menu">☰</button>
+    <nav aria-label="Primary">
+      <button class="ghost" type="button" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
     </nav>
   </div>
 </header>
 <main>
-  <article style="max-width:800px; margin:2rem auto; padding:0 1rem;">
-    <h1>About Heirloom</h1>
-    <section>
-      <h2>The Spark</h2>
-      <p>Heirloom began with a simple, stubborn question: why do our best memories live in a thousand places and still slip away? Phones get replaced, platforms change, and family stories scatter. We built Heirloom to pull the threads together—your photos, videos, notes, voice logs, little moments—and weave them into something that lasts.</p>
+  <section class="hero-about page-wrap">
+    <div class="grid grid-cols-1 grid-cols-2@lg items-center">
+      <div>
+        <p class="eyebrow">About Heirloom</p>
+        <h1>About Heirloom</h1>
+        <p class="lede">We build tools so every family's story endures.</p>
+      </div>
+      <div aria-hidden="true" class="accent justify-end">
+        <svg viewBox="0 0 120 120" width="120" height="120">
+          <circle cx="60" cy="60" r="50" fill="currentColor" opacity=".05"/>
+          <circle cx="60" cy="60" r="25" fill="currentColor" opacity=".1"/>
+        </svg>
+      </div>
+    </div>
+  </section>
+  <article class="page-wrap grid grid-cols-1 grid-cols-2@lg items-start">
+    <section class="card" aria-labelledby="spark">
+      <h2 id="spark">The Spark</h2>
+      <p>Heirloom began with a simple, stubborn question: why do our best memories live in a thousand places and still slip away?</p>
+      <p>Phones get replaced, platforms change, and family stories scatter. We built Heirloom to pull the threads together—your photos, videos, notes, voice logs, little moments—and weave them into something that lasts.</p>
+      <blockquote class="pullquote">We built Heirloom to pull the threads together—your photos, videos, notes, voice logs, little moments—and weave them into something that lasts.</blockquote>
     </section>
-    <section>
-      <h2>What Heirloom Does Today</h2>
-      <ul>
-        <li>Capture the everyday: quick journals, voice notes, photos, and milestones that slot right into a private timeline.</li>
-        <li>Ingest the past: pull in old albums and files, keep originals organized, and de-duplicate safely.</li>
-        <li>Recall with context: find moments by people, places, dates, or even vibes—“that rainy day in June with the dogs.”</li>
-        <li>Tell the story: draft multi-chapter life stories from your timeline, with citations back to your own memories.</li>
-        <li>Share, selectively: invite family into specific albums or chapters—private by default, on your terms.</li>
+    <section class="card span-all" aria-labelledby="features">
+      <h2 id="features">What Heirloom Does Today</h2>
+      <div class="grid grid-cols-2@lg grid-cols-3@xl">
+        <div class="card">
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke="currentColor" fill="none"/><line x1="8" y1="8" x2="16" y2="8" stroke="currentColor"/></svg>
+          <h3>Capture the everyday</h3>
+          <p>quick journals, voice notes, photos, and milestones that slot right into a private timeline.</p>
+        </div>
+        <div class="card">
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><path d="M12 5v14M5 12h14" stroke="currentColor" fill="none"/></svg>
+          <h3>Ingest the past</h3>
+          <p>pull in old albums and files, keep originals organized, and de-duplicate safely.</p>
+        </div>
+        <div class="card">
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><circle cx="11" cy="11" r="7" stroke="currentColor" fill="none"/><line x1="16.65" y1="16.65" x2="21" y2="21" stroke="currentColor"/></svg>
+          <h3>Recall with context</h3>
+          <p>find moments by people, places, dates, or even vibes—“that rainy day in June with the dogs.”</p>
+        </div>
+        <div class="card">
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><path d="M4 4h16v16H4z" stroke="currentColor" fill="none"/><path d="M8 8h8v8H8z" stroke="currentColor" fill="none"/></svg>
+          <h3>Tell the story</h3>
+          <p>draft multi-chapter life stories from your timeline, with citations back to your own memories.</p>
+        </div>
+        <div class="card">
+          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><path d="M12 5v14" stroke="currentColor" fill="none"/><path d="M5 12l7-7 7 7" stroke="currentColor" fill="none"/></svg>
+          <h3>Share, selectively</h3>
+          <p>invite family into specific albums or chapters—private by default, on your terms.</p>
+        </div>
+      </div>
+    </section>
+    <section class="card span-all" aria-labelledby="whats-next">
+      <h2 id="whats-next">What’s Next</h2>
+      <ul class="timeline">
+        <li class="timeline-item">Genealogy mode: understand relationships across generations, blending family trees with real memories.</li>
+        <li class="timeline-item">General Chat: ask natural questions about your life (“When did we visit Acadia?”), and get answers grounded in your data. Or just any question about anything ("When did the Browns win the Super Bowl")</li>
+        <li class="timeline-item">Posthumous releases: schedule messages or chapters to be shared later, with proper controls and consent.</li>
+        <li class="timeline-item">Talk to Me: Your voice, your personality, your memories — preserved so family can still talk with you.</li>
+        <li class="timeline-item">Deeper search: richer queries across emotions, locations, and recurring rituals.</li>
       </ul>
     </section>
-    <section>
-      <h2>What’s Next</h2>
-      <ul>
-        <li>Genealogy mode: understand relationships across generations, blending family trees with real memories.</li>
-        <li>General Chat: ask natural questions about your life (“When did we visit Acadia?”), and get answers grounded in your data. Or just any question about anything ("When did the Browns win the Super Bowl")</li>
-        <li>Posthumous releases: schedule messages or chapters to be shared later, with proper controls and consent.</li>
-        <li>Talk to Me: Your voice, your personality, your memories — preserved so family can still talk with you.</li>
-        <li>Deeper search: richer queries across emotions, locations, and recurring rituals.</li>
+    <section class="card" aria-labelledby="long-view">
+      <h2 id="long-view">The Long View</h2>
+      <ul class="timeline">
+        <li class="timeline-item">Local-first hardware: a dedicated HeirloomOS device for full offline operation, GPU-powered recall, and long-term archival at home.</li>
+        <li class="timeline-item">Seamless migration: start in the web app, move to hardware when you’re ready—same account, same memories, no lock-in.</li>
+        <li class="timeline-item">Privacy as a principle: client-side encryption options, no data resale. Your stories stay yours.</li>
       </ul>
     </section>
-    <section>
-      <h2>The Long View</h2>
-      <ul>
-        <li>Local-first hardware: a dedicated HeirloomOS device for full offline operation, GPU-powered recall, and long-term archival at home.</li>
-        <li>Seamless migration: start in the web app, move to hardware when you’re ready—same account, same memories, no lock-in.</li>
-        <li>Privacy as a principle: client-side encryption options, no data resale. Your stories stay yours.</li>
-      </ul>
-    </section>
-    <section>
-      <h2>Why It Matters</h2>
+    <section class="card" aria-labelledby="why-matters">
+      <h2 id="why-matters">Why It Matters</h2>
       <p>Memories are more than files; they’re the connective tissue of a family. Heirloom’s job is to protect them, organize them, and help them speak.</p>
+    </section>
+    <section class="card" aria-labelledby="what-today">
+      <h2 id="what-today">What Heirloom Is (Today)</h2>
+      <p>Heirloom is a simple place to journal and capture voice notes, keeping moments together in one private timeline.</p>
+    </section>
+    <section class="card" aria-labelledby="privacy">
+      <h2 id="privacy">Privacy-First by Design</h2>
+      <p>Heirloom keeps your data under your control. Memories live locally first with straightforward export options whenever you need them.</p>
+    </section>
+    <section class="card span-all" aria-labelledby="road-ahead">
+      <h2 id="road-ahead">Road Ahead (12-Month Snapshot)</h2>
+      <ul class="timeline">
+        <li class="timeline-item"><span class="status">planned</span> Mobile app preview for quick captures on the go.</li>
+        <li class="timeline-item"><span class="status">planned</span> Optional desktop uploader for batch imports.</li>
+        <li class="timeline-item"><span class="status">planned</span> Improved search filters across dates and people.</li>
+        <li class="timeline-item"><span class="status">planned</span> Early sharing tools to loop in close family.</li>
+      </ul>
+    </section>
+    <section class="card" aria-labelledby="talk">
+      <h2 id="talk">Talk to Me</h2>
+      <p>A voice that sounds like you, trained on how you speak, so your loved ones can hear you—and speak with you—even long after today.</p>
+    </section>
+    <section class="card" aria-labelledby="founder">
+      <h2 id="founder">Founder’s Note</h2>
+      <p>Heirloom started as a weekend project to keep one family’s stories from fading. It grew into a mission to make remembering easy for everyone.</p>
+    </section>
+    <section class="card span-all" id="faq-section" aria-labelledby="faq-heading">
+      <h2 id="faq-heading">FAQ</h2>
+      <nav aria-label="FAQ">
+        <dl>
+          <div>
+            <dt id="faq-pricing">How much will it cost?</dt>
+            <dd>Pricing is still being shaped. There will be a free tier at launch.</dd>
+          </div>
+          <div>
+            <dt id="faq-export">Can I export my data?</dt>
+            <dd>Yes—export tools will let you download your memories whenever you like.</dd>
+          </div>
+          <div>
+            <dt id="faq-platform">Which platforms are supported?</dt>
+            <dd>Heirloom runs in your browser today with mobile apps planned.</dd>
+          </div>
+          <div>
+            <dt id="faq-support">How do I get support?</dt>
+            <dd>Reach out anytime via the contact form and we'll help out.</dd>
+          </div>
+          <div>
+            <dt id="faq-tbd">Is pricing finalized?</dt>
+            <dd>Not yet—the details are still to be determined.</dd>
+          </div>
+        </dl>
+      </nav>
+    </section>
+    <section class="card" aria-labelledby="press">
+      <h2 id="press">Press &amp; Assets</h2>
+      <p><a href="/assets/brand.zip">Download logo pack</a> · <a href="/contact.html">Media contact</a></p>
+    </section>
+    <section class="cta-strip span-all">
+      <p>Follow progress on the roadmap</p>
+      <div class="grid cta-links">
+        <a href="/roadmap.html">Roadmap</a>
+        <a href="/contact.html">Contact</a>
+      </div>
     </section>
   </article>
 </main>
 <footer>
   <p>© Heirloom</p>
-  <nav>
+  <nav aria-label="Footer">
     <a href="/roadmap.html">Roadmap</a> •
     <a href="/privacy.html">Privacy</a> •
     <a href="/contact.html">Contact</a>

--- a/css/styles.css
+++ b/css/styles.css
@@ -14,6 +14,7 @@ input,button,textarea,select{font:inherit;}
  --ring:#ffc8b3;
  --border:#f2d9cf;
  --max-width:72rem;
+ --shadow-sm:0 1px 2px rgba(0,0,0,.04);
 }
 html[data-theme='dark']{
  --bg:#0f1115;
@@ -23,6 +24,7 @@ html[data-theme='dark']{
  --muted:#9aa4b2;
  --ring:#334155;
  --border:#1f2630;
+ --shadow-sm:0 1px 2px rgba(0,0,0,.5);
 }
 body{
 background:var(--bg);color:var(--ink);font-family:Inter,system-ui,sans-serif;display:flex;flex-direction:column;}
@@ -54,7 +56,8 @@ footer a{color:var(--muted);}
 .milestone::before{content:"";position:absolute;left:-1rem;top:.5rem;width:12px;height:12px;border-radius:50%;background:var(--brand);}
 .status{display:inline-block;padding:.125rem .5rem;border-radius:8px;font-size:.75rem;background:var(--border);color:var(--ink);margin-bottom:.5rem;}
 @media(max-width:600px){.timeline{padding-left:1rem;}.milestone{padding-left:1rem;}.milestone::before{left:-.75rem;}}
-.grid{display:grid;gap:1rem;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));}
+.grid{display:grid;gap:1.25rem;}
+.tiles .grid{grid-template-columns:repeat(auto-fit,minmax(200px,1fr));}
 .tiles{max-width:var(--max-width);margin:2rem auto;padding:0 1rem;}
 .tile{display:block;padding:1.5rem;border:1px solid var(--border);border-radius:12px;background:var(--bg-elev);text-align:center;transition:background .2s,border-color .2s;}
 .tile h2{margin-bottom:.5rem;}
@@ -75,7 +78,7 @@ html[data-theme='dark'] .beehiiv-embed{filter:invert(1) hue-rotate(180deg);}
 .page-wrap{max-width:var(--max-width);margin:0 auto;padding:2rem 1rem;}
 .grid-contact{display:grid;gap:2rem;}
 @media(min-width:1024px){.grid-contact{grid-template-columns:380px 1fr;}}
-.card{background:var(--bg-elev);border:1px solid var(--border);border-radius:12px;box-shadow:0 2px 4px rgba(0,0,0,.05);padding:1.5rem;}
+.card{background:var(--bg-elev);border:1px solid var(--border);border-radius:16px;box-shadow:var(--shadow-sm);padding:1.2rem;}
 .info-panel address{font-style:normal;line-height:1.6;}
 .social-list{display:flex;gap:.5rem;list-style:none;padding:0;margin-top:1rem;}
 .utilities{list-style:none;padding:0;margin-top:1rem;display:flex;flex-direction:column;gap:.5rem;}
@@ -84,3 +87,22 @@ html[data-theme='dark'] .beehiiv-embed{filter:invert(1) hue-rotate(180deg);}
 .notes{padding-left:1.25rem;line-height:1.6;}
 .notes li{margin-bottom:.5rem;}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0 0 0 0);white-space:nowrap;border:0;}
+
+.eyebrow{text-transform:uppercase;letter-spacing:.08em;font-size:.8rem;opacity:.8;margin-bottom:.25rem;}
+.lede{font-size:clamp(1.05rem,1.1vw + 1rem,1.35rem);line-height:1.6;}
+@media(min-width:1024px){.grid-cols-2@lg{grid-template-columns:1fr 1fr;}}
+@media(min-width:1280px){.grid-cols-3@xl{grid-template-columns:repeat(3,1fr);}}
+.timeline{position:relative;padding-left:1.25rem;}
+.timeline::before{content:"";position:absolute;left:.5rem;top:0;bottom:0;width:2px;background:currentColor;opacity:.12;}
+.timeline-item{position:relative;padding-left:1rem;}
+.timeline-item::before{content:"";position:absolute;left:-.33rem;top:.4rem;width:.5rem;height:.5rem;border-radius:50%;background:currentColor;}
+.pullquote{font-size:1.15rem;line-height:1.6;border-left:4px solid currentColor;padding-left:1rem;opacity:.9;margin:1.5rem 0;}
+.cta-strip{display:flex;gap:.75rem;flex-wrap:wrap;align-items:center;justify-content:space-between;padding:1rem 1.25rem;border:1px solid var(--border);border-radius:14px;background:var(--bg-elev);}
+.card .timeline{margin:0;}
+.cta-strip a{background:var(--brand);color:#fff;padding:.5rem 1rem;border-radius:12px;text-decoration:none;}
+.cta-strip a:hover{text-decoration:underline;}
+.items-center{align-items:center;}
+.items-start{align-items:start;}
+.justify-end{justify-self:end;}
+.span-all{grid-column:1/-1;}
+.cta-links{grid-template-columns:repeat(auto-fit,minmax(120px,1fr));}

--- a/js/main.js
+++ b/js/main.js
@@ -38,4 +38,20 @@
       phoneLink.href = `tel:${digits}`;
     }
   }
+  document.querySelectorAll('#faq-section dt').forEach(dt=>{
+    const id = dt.id;
+    if(!id) return;
+    const btn = document.createElement('button');
+    btn.className='ghost';
+    btn.textContent='🔗';
+    btn.setAttribute('aria-label','Copy link');
+    btn.addEventListener('click',()=>{
+      const url = `${location.origin}${location.pathname}#${id}`;
+      navigator.clipboard?.writeText(url);
+    });
+    dt.appendChild(btn);
+  });
+  if(window.matchMedia('(prefers-reduced-motion: reduce)').matches){
+    document.documentElement.style.setProperty('scroll-behavior','auto');
+  }
 })();


### PR DESCRIPTION
## Summary
- Rebuilt About page with hero, feature grid and new editorial sections
- Added utility CSS classes for grid, cards, timeline, pull quotes and CTA strip
- Appended FAQ copy-link script and reduced-motion handling

## Testing
- `npx prettier -c about.html css/styles.css js/main.js`
- `npx -y html-validate about.html`

------
https://chatgpt.com/codex/tasks/task_e_68bb918ac908832e823a200c00658b9c