### PR TITLE
Remove social and map links from contact page

### DIFF
--- a/contact.html
+++ b/contact.html
@@ -49,13 +49,7 @@
           <a data-email href="mailto:TryHeirloomAi@gmail.com">TryHeirloomAi@gmail.com</a><br>
           <a data-phone href="tel:+12073788660">(207) 378-8660</a>
         </address>
-        <ul class="social-list">
-          <li><a href="#" rel="me">Twitter/X</a></li>
-          <li><a href="#" rel="me">Instagram</a></li>
-          <li><a href="https://www.youtube.com/@603Outsiders" rel="me">YouTube</a></li>
-        </ul>
         <ul class="utilities" aria-label="Contact utilities">
-          <li><a id="map-link" href="#" rel="noopener">Open in Maps</a></li>
           <li><a id="vcard-link" href="/assets/contact.vcf" download>Download vCard (.vcf)</a></li>
         </ul>
       </section>


### PR DESCRIPTION
## Summary
- Remove Twitter, Instagram, and YouTube links from the contact page
- Drop "Open in Maps" utility link

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7b1bd9c4832e82ac8bd1386417a3