### PR TITLE
Refactor About page into single-column narrative

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,11 +12,11 @@
   </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>About Heirloom</title>
-  <meta name="description" content="Heirloom's origin story, features, and vision.">
+  <title>About Heirloom | Private journaling and voice capture</title>
+  <meta name="description" content="About Heirloom—private journaling and voice capture built for decades.">
   <link rel="canonical" href="https://www.tryheirloomai.com/about.html">
-  <meta property="og:title" content="About Heirloom">
-  <meta property="og:description" content="Heirloom's origin story, features, and vision.">
+  <meta property="og:title" content="About Heirloom | Private journaling and voice capture">
+  <meta property="og:description" content="About Heirloom—private journaling and voice capture built for decades.">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
@@ -34,142 +34,86 @@
   </div>
 </header>
 <main>
-  <section class="hero-about page-wrap">
-    <div class="grid grid-cols-1 grid-cols-2@lg items-center">
-      <div>
-        <p class="eyebrow">About Heirloom</p>
-        <h1>About Heirloom</h1>
-        <p class="lede">We build tools so every family's story endures.</p>
-      </div>
-      <div aria-hidden="true" class="accent justify-end">
-        <svg viewBox="0 0 120 120" width="120" height="120">
-          <circle cx="60" cy="60" r="50" fill="currentColor" opacity=".05"/>
-          <circle cx="60" cy="60" r="25" fill="currentColor" opacity=".1"/>
-        </svg>
-      </div>
-    </div>
-  </section>
-  <article class="page-wrap grid grid-cols-1 grid-cols-2@lg items-start">
-    <section class="card" aria-labelledby="spark">
-      <h2 id="spark">The Spark</h2>
-      <p>Heirloom began with a simple, stubborn question: why do our best memories live in a thousand places and still slip away?</p>
-      <p>Phones get replaced, platforms change, and family stories scatter. We built Heirloom to pull the threads together—your photos, videos, notes, voice logs, little moments—and weave them into something that lasts.</p>
-      <blockquote class="pullquote">We built Heirloom to pull the threads together—your photos, videos, notes, voice logs, little moments—and weave them into something that lasts.</blockquote>
+  <article>
+    <section class="about-hero">
+      <img src="/assets/logo.svg" alt="Heirloom brand mark">
+      <h1>About Heirloom</h1>
+      <p class="lede">Build a living archive of your life—one entry, one voice note at a time.</p>
+      <p>Heirloom helps you capture daily thoughts, speak your memories out loud, and keep them safe for the people who matter. Private by default. Built for decades.</p>
     </section>
-    <section class="card span-all" aria-labelledby="features">
-      <h2 id="features">What Heirloom Does Today</h2>
-      <div class="grid grid-cols-2@lg grid-cols-3@xl">
-        <div class="card">
-          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><rect x="3" y="4" width="18" height="16" rx="2" ry="2" stroke="currentColor" fill="none"/><line x1="8" y1="8" x2="16" y2="8" stroke="currentColor"/></svg>
-          <h3>Capture the everyday</h3>
-          <p>quick journals, voice notes, photos, and milestones that slot right into a private timeline.</p>
-        </div>
-        <div class="card">
-          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><path d="M12 5v14M5 12h14" stroke="currentColor" fill="none"/></svg>
-          <h3>Ingest the past</h3>
-          <p>pull in old albums and files, keep originals organized, and de-duplicate safely.</p>
-        </div>
-        <div class="card">
-          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><circle cx="11" cy="11" r="7" stroke="currentColor" fill="none"/><line x1="16.65" y1="16.65" x2="21" y2="21" stroke="currentColor"/></svg>
-          <h3>Recall with context</h3>
-          <p>find moments by people, places, dates, or even vibes—“that rainy day in June with the dogs.”</p>
-        </div>
-        <div class="card">
-          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><path d="M4 4h16v16H4z" stroke="currentColor" fill="none"/><path d="M8 8h8v8H8z" stroke="currentColor" fill="none"/></svg>
-          <h3>Tell the story</h3>
-          <p>draft multi-chapter life stories from your timeline, with citations back to your own memories.</p>
-        </div>
-        <div class="card">
-          <svg aria-hidden="true" viewBox="0 0 24 24" width="24" height="24"><path d="M12 5v14" stroke="currentColor" fill="none"/><path d="M5 12l7-7 7 7" stroke="currentColor" fill="none"/></svg>
-          <h3>Share, selectively</h3>
-          <p>invite family into specific albums or chapters—private by default, on your terms.</p>
-        </div>
-      </div>
+
+    <section class="about-section" id="story">
+      <h2>Why we’re building Heirloom</h2>
+      <p>Some memories vanish in tiny ways—the sound of a laugh, the way someone told a story. Heirloom began as a promise to hold on to those details before they fade. We’re building a simple, durable place to put your days: words you’ve written, thoughts you’ve spoken, moments you don’t want to lose. Not a feed. Not a trend. A home for what matters across a lifetime.</p>
     </section>
-    <section class="card span-all" aria-labelledby="whats-next">
-      <h2 id="whats-next">What’s Next</h2>
-      <ul class="timeline">
-        <li class="timeline-item">Genealogy mode: understand relationships across generations, blending family trees with real memories.</li>
-        <li class="timeline-item">General Chat: ask natural questions about your life (“When did we visit Acadia?”), and get answers grounded in your data. Or just any question about anything ("When did the Browns win the Super Bowl")</li>
-        <li class="timeline-item">Posthumous releases: schedule messages or chapters to be shared later, with proper controls and consent.</li>
-        <li class="timeline-item">Talk to Me: Your voice, your personality, your memories — preserved so family can still talk with you.</li>
-        <li class="timeline-item">Deeper search: richer queries across emotions, locations, and recurring rituals.</li>
+
+    <section class="about-section" id="what-is">
+      <h2>What is Heirloom?</h2>
+      <p>Heirloom is a private, long-term memory home. Start with journaling and voice notes.</p>
+      <p>Over time, your entries stack into a clear, searchable record of your life—something you can return to, share selectively, and preserve.</p>
+    </section>
+
+    <section class="about-section" id="focus">
+      <h2>What we’re building first</h2>
+      <p>In our first year, we’re focused on doing a few things exceptionally well:</p>
+      <ul>
+        <li>Journaling: Write daily entries with timestamps.</li>
+        <li>Voice capture: Record voice notes; automatic transcription.</li>
+        <li>Private by default: Your data stays yours.</li>
+        <li>Clean timeline: See your days stack into a life.</li>
+        <li>Export-ready foundation: Laying groundwork for local backups.</li>
       </ul>
+      <p>These are the core stones of our first year.</p>
     </section>
-    <section class="card" aria-labelledby="long-view">
-      <h2 id="long-view">The Long View</h2>
-      <ul class="timeline">
-        <li class="timeline-item">Local-first hardware: a dedicated HeirloomOS device for full offline operation, GPU-powered recall, and long-term archival at home.</li>
-        <li class="timeline-item">Seamless migration: start in the web app, move to hardware when you’re ready—same account, same memories, no lock-in.</li>
-        <li class="timeline-item">Privacy as a principle: client-side encryption options, no data resale. Your stories stay yours.</li>
-      </ul>
+
+    <section class="about-section" id="how">
+      <h2>How it works</h2>
+      <p>Sign in and you’re on your timeline. Write a journal entry or tap record to speak a thought out loud.</p>
+      <p>We transcribe your voice note and keep the audio. Entries are organized by day so you can skim your timeline. Early search lets you pull up moments by date or keyword.</p>
+      <p>As we iterate, search and export options will expand—carefully, with privacy as the guiding rule.</p>
     </section>
-    <section class="card" aria-labelledby="why-matters">
-      <h2 id="why-matters">Why It Matters</h2>
-      <p>Memories are more than files; they’re the connective tissue of a family. Heirloom’s job is to protect them, organize them, and help them speak.</p>
+
+    <section class="about-section" id="privacy">
+      <h2>Privacy first. Your stories, your rules.</h2>
+      <p>Your data is your story. We’re building Heirloom with a privacy-first mindset: no ad targeting, transparent processing, and practical export options so you’re never trapped.</p>
+      <p>Longevity matters; we’re optimizing for decades, not quarters. Local-first foundations guide our future so your memories remain under your control.</p>
     </section>
-    <section class="card" aria-labelledby="what-today">
-      <h2 id="what-today">What Heirloom Is (Today)</h2>
-      <p>Heirloom is a simple place to journal and capture voice notes, keeping moments together in one private timeline.</p>
+
+    <section class="about-section" id="roadmap">
+      <h2>What’s next</h2>
+      <p>Curious what’s next? See our <a href="/roadmap.html">public roadmap</a> for the next 12 months.</p>
     </section>
-    <section class="card" aria-labelledby="privacy">
-      <h2 id="privacy">Privacy-First by Design</h2>
-      <p>Heirloom keeps your data under your control. Memories live locally first with straightforward export options whenever you need them.</p>
+
+    <section class="about-section" id="team">
+      <h2>The people behind Heirloom</h2>
+      <p>We’re a small team of builders, designers, and patient testers who care about reliability and longevity. No resumes, just humans working to keep memories safe and meaningful for the long haul.</p>
     </section>
-    <section class="card span-all" aria-labelledby="road-ahead">
-      <h2 id="road-ahead">Road Ahead (12-Month Snapshot)</h2>
-      <ul class="timeline">
-        <li class="timeline-item"><span class="status">planned</span> Mobile app preview for quick captures on the go.</li>
-        <li class="timeline-item"><span class="status">planned</span> Optional desktop uploader for batch imports.</li>
-        <li class="timeline-item"><span class="status">planned</span> Improved search filters across dates and people.</li>
-        <li class="timeline-item"><span class="status">planned</span> Early sharing tools to loop in close family.</li>
-      </ul>
+
+    <section class="about-section" id="faq">
+      <h2>FAQ</h2>
+      <dl>
+        <div>
+          <dt>When can I try it?</dt>
+          <dd>We’re building toward the first release focused on journaling and voice capture within the next 12 months; check the roadmap.</dd>
+        </div>
+        <div>
+          <dt>Will my data be private?</dt>
+          <dd>Yes, privacy is core; more on export and backups as we progress.</dd>
+        </div>
+        <div>
+          <dt>Will there be mobile?</dt>
+          <dd>We’re building web-first; mobile access and flows are a priority as we approach release.</dd>
+        </div>
+        <div>
+          <dt>How do I follow progress?</dt>
+          <dd>Keep an eye on the <a href="/roadmap.html">roadmap</a> and any dev updates or newsletter already present.</dd>
+        </div>
+      </dl>
     </section>
-    <section class="card" aria-labelledby="talk">
-      <h2 id="talk">Talk to Me</h2>
-      <p>A voice that sounds like you, trained on how you speak, so your loved ones can hear you—and speak with you—even long after today.</p>
-    </section>
-    <section class="card" aria-labelledby="founder">
-      <h2 id="founder">Founder’s Note</h2>
-      <p>Heirloom started as a weekend project to keep one family’s stories from fading. It grew into a mission to make remembering easy for everyone.</p>
-    </section>
-    <section class="card span-all" id="faq-section" aria-labelledby="faq-heading">
-      <h2 id="faq-heading">FAQ</h2>
-      <nav aria-label="FAQ">
-        <dl>
-          <div>
-            <dt id="faq-pricing">How much will it cost?</dt>
-            <dd>Pricing is still being shaped. There will be a free tier at launch.</dd>
-          </div>
-          <div>
-            <dt id="faq-export">Can I export my data?</dt>
-            <dd>Yes—export tools will let you download your memories whenever you like.</dd>
-          </div>
-          <div>
-            <dt id="faq-platform">Which platforms are supported?</dt>
-            <dd>Heirloom runs in your browser today with mobile apps planned.</dd>
-          </div>
-          <div>
-            <dt id="faq-support">How do I get support?</dt>
-            <dd>Reach out anytime via the contact form and we'll help out.</dd>
-          </div>
-          <div>
-            <dt id="faq-tbd">Is pricing finalized?</dt>
-            <dd>Not yet—the details are still to be determined.</dd>
-          </div>
-        </dl>
-      </nav>
-    </section>
-    <section class="card" aria-labelledby="press">
-      <h2 id="press">Press &amp; Assets</h2>
-      <p><a href="/assets/brand.zip">Download logo pack</a> · <a href="/contact.html">Media contact</a></p>
-    </section>
-    <section class="cta-strip span-all">
-      <p>Follow progress on the roadmap</p>
-      <div class="grid cta-links">
-        <a href="/roadmap.html">Roadmap</a>
-        <a href="/contact.html">Contact</a>
-      </div>
+
+    <section class="about-cta">
+      <p>Want updates and early access when we hit key milestones?</p>
+      <a href="/#waitlist" class="join-waitlist">Join the waitlist</a>
     </section>
   </article>
 </main>

--- a/css/styles.css
+++ b/css/styles.css
@@ -106,3 +106,20 @@ html[data-theme='dark'] .beehiiv-embed{filter:invert(1) hue-rotate(180deg);}
 .justify-end{justify-self:end;}
 .span-all{grid-column:1/-1;}
 .cta-links{grid-template-columns:repeat(auto-fit,minmax(120px,1fr));}
+
+/* About page */
+.about-hero{max-width:72ch;margin:0 auto;text-align:center;padding:2rem 1rem;}
+.about-hero img{width:80px;margin:0 auto 1rem;}
+.about-section{max-width:72ch;margin:0 auto;padding:2rem 1rem;border-top:1px solid var(--border);line-height:1.6;}
+.about-section h2{margin-bottom:.75rem;}
+.about-section ul{list-style:disc;margin-left:1.25rem;margin-top:.5rem;}
+.about-section ul li+li{margin-top:.25rem;}
+.about-cta{max-width:72ch;margin:0 auto;text-align:center;padding:2rem 1rem;border-top:1px solid var(--border);}
+.about-cta .join-waitlist{display:inline-block;margin-top:.5rem;background:var(--brand);color:#fff;padding:.5rem 1rem;border-radius:12px;text-decoration:none;}
+.about-cta .join-waitlist:hover{text-decoration:underline;}
+
+@media(min-width:768px){
+  .about-hero{padding:4rem 1rem 3rem;}
+  .about-section{padding:3rem 1rem;}
+  .about-cta{padding:3rem 1rem;}
+}


### PR DESCRIPTION
## Summary
- Replace tile/card About layout with a long-form narrative covering hero, story, product focus, how it works, privacy, roadmap, team, FAQ, and waitlist CTA
- Update meta title and description to reflect private journaling and voice capture
- Add about-specific CSS for single-column rhythm, section dividers, and responsive waitlist button

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bc7c9652e8832eb67d24372938319d