### PR TITLE
Add structured placeholders for future pitch sections

### DIFF
--- a/full-pitch.html
+++ b/full-pitch.html
@@ -156,6 +156,104 @@
         <p>Hardware Transition Risk. Mitigated by sequencing: SaaS first, hardware only after adoption and revenue.</p>
         <p>Founder &amp; Team Risk. Mitigated by clear role division and regular alignment checkpoints.</p>
       </section>
+        <section id="team-advisors" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Team & Advisors</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="go-to-market" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Go-to-Market Plan</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="market-size-why-now" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Market Size & Why Now</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="competitive-landscape" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Competitive Landscape</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="security-privacy-compliance" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Security, Privacy & Compliance</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="technical-architecture" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Technical Architecture</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="unit-economics-pricing" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Unit Economics & Pricing Detail</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="financial-model-36m" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>36-Month Financial Model</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="traction-validation" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Traction & Validation</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="roadmap-milestones" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Roadmap & Dated Milestones</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="legal-ip" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Legal & IP</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="round-terms" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Terms of the Round</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="support-accessibility" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Customer Support & Accessibility</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
+        <section id="appendices" class="pitch-section">
+          <p class="overline">Section</p>
+          <h2>Appendices (Sources, Assumptions, Glossary)</h2>
+          <div class="section-body">
+            <!-- INSERT VERBATIM TEXT HERE LATER -->
+          </div>
+        </section>
       <section id="closing-vision" class="pitch-section">
         <h2>Closing &amp; Vision</h2>
         <p>Heirloom is more than software. It is a mission to preserve the essence of human life in a way that is accessible, enduring, and deeply personal. Every generation has struggled with the problem of memory loss—not just the fading of individual recollections, but the loss of entire family histories as voices are silenced and stories go untold. Heirloom exists to change that trajectory.</p>


### PR DESCRIPTION
## Summary
- add 14 placeholder sections before Closing & Vision on full-pitch page
- wire up anchors so new sections appear in Table of Contents

## Testing
- `npx --yes htmlhint full-pitch.html`

------
https://chatgpt.com/codex/tasks/task_e_68bc94ab6198832eb12969d8a76bbc8b