### PR TITLE
Add Team & Advisor details to company pitch

### DIFF
--- a/full-pitch.html
+++ b/full-pitch.html
@@ -169,7 +169,44 @@
           <p class="overline">Section</p>
           <h2>Team & Advisors</h2>
           <div class="section-body">
-            <!-- INSERT VERBATIM TEXT HERE LATER -->
+            <h3>Founder &amp; CEO — Derek Evans</h3>
+            <p>Product-led founder with Navy-forged discipline, a background in network administration/ethical hacking, and hands-on experience automating real operations at Granite Ledge Coffee. Building Heirloom as a privacy-first, family-centric platform with a disciplined, milestone-driven roadmap.</p>
+            <h4>Core responsibilities</h4>
+            <ul>
+              <li>Product vision, UX, and roadmap ownership</li>
+              <li>Engineering leadership and vendor selection</li>
+              <li>Security/privacy posture and data governance standards</li>
+              <li>Fundraising, partnerships, and early GTM execution</li>
+              <li>Operating cadence, metrics, and budget discipline</li>
+            </ul>
+            <h4>Relevant experience</h4>
+            <ul>
+              <li>Network administration &amp; ethical hacking: secure systems mindset, automation, incident hygiene</li>
+              <li>Entrepreneurial operations (Granite Ledge Coffee): order workflows, shipping/logistics automation, reliability under real-world constraints</li>
+              <li>Full-stack build/ship culture: rapid prototyping, iterative releases, telemetry-driven improvements</li>
+            </ul>
+            <h3>Advisory Board (forming)</h3>
+            <ul>
+              <li>Privacy &amp; Security Advisor — Threat modeling, encryption/key management choices, data retention/deletion policies, compliance roadmap (GDPR/CCPA/COPPA posture).</li>
+              <li>AI/ML Systems Advisor — Model selection, cost/performance tradeoffs, evals, and on-device inference strategy for HeirloomOS.</li>
+              <li>Consumer SaaS Growth Advisor — Activation → retention loop design, pricing tests, referral mechanics, and analytics instrumentation.</li>
+              <li>Genealogy/Partnerships Advisor — Integrations landscape, data standards, and distribution through family-history communities.</li>
+              <li>Legal &amp; Corporate Advisor — Data ownership terms, IP/trademark strategy, contractor &amp; advisor agreements, fundraising documents.</li>
+            </ul>
+            <p>Compensation norms: standard early-stage advisor grants (e.g., ~0.25–1.0% each, 2-year vest, monthly, no cliff), adjusted by involvement level.</p>
+            <h3>Hiring Plan (Year 1 — lean)</h3>
+            <ul>
+              <li>Founding Engineer (Full-stack) – Owns core journaling/voice capture, auth, and billing; sets code standards.</li>
+              <li>Product Designer (Contract → FT) – Information architecture, mobile-first flows, accessibility, and design system.</li>
+              <li>Backend/Infra Engineer (Contract) – Storage pipelines, search, observability, cost controls, and backup/DR targets.</li>
+            </ul>
+            <p>Operating model: founder-owned delivery with selective contractors; option to convert high-leverage contributors to early employees after product-market signal.</p>
+            <h3>Structure &amp; Ownership (at raise)</h3>
+            <ul>
+              <li>Current status: founder-owned.</li>
+              <li>Planned option pool: 10–15% to support first hires and key advisors (final size set at or before close).</li>
+              <li>Governance: lightweight board/observer structure appropriate for an angel round; monthly metrics cadence.</li>
+            </ul>
           </div>
         </section>
         <section id="go-to-market" class="pitch-section">


### PR DESCRIPTION
## Summary
- flesh out Team & Advisors section with founder profile, advisory board roles, hiring plan, and ownership structure

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcb4e9c204832e99a0e0e8e6c7c805