### PR TITLE
Add go-to-market plan to company pitch

### DIFF
--- a/full-pitch.html
+++ b/full-pitch.html
@@ -213,7 +213,112 @@
           <p class="overline">Section</p>
           <h2>Go-to-Market Plan</h2>
           <div class="section-body">
-            <!-- INSERT VERBATIM TEXT HERE LATER -->
+            <h3>Objective</h3>
+            <p>Prove demand, convert early families to paying subscribers, and build a durable acquisition flywheel—while protecting privacy and brand trust.</p>
+
+            <h3>Ideal Customer Profiles (ICPs) &amp; Core Use Cases</h3>
+            <ul>
+              <li><strong>New parents &amp; expecting parents</strong> — capture voice notes, daily moments, milestones from birth onward.</li>
+              <li><strong>Family historians / genealogy-minded families</strong> — organize decades of photos, dates, and oral histories.</li>
+              <li><strong>Elder-care &amp; legacy planners</strong> — record stories/voices before they’re lost; enable posthumous releases.</li>
+              <li><strong>Multigenerational households</strong> — shared archive with roles/permissions (parents, teens, grandparents).</li>
+              <li><strong>Pet families (adjacent ICP)</strong> — journaling, photos, and voice tied to pets as part of family memory.</li>
+            </ul>
+
+            <h3>Positioning &amp; Messaging Pillars</h3>
+            <ul>
+              <li><strong>Privacy-first, family-first.</strong> Your memories aren’t ad inventory. You own the archive.</li>
+              <li><strong>Effortless capture.</strong> Daily journaling + one-tap voice notes; low friction beats good intentions.</li>
+              <li><strong>Recall with meaning.</strong> Natural-language search and context, not just files.</li>
+              <li><strong>Built to last.</strong> Export anytime; future path to local HeirloomOS custody.</li>
+              <li><strong>Shared legacy.</strong> Multi-user by design; a single family story with many voices.</li>
+            </ul>
+
+            <h3>Funnel &amp; Conversion Targets (Y1)</h3>
+            <ul>
+              <li>Waitlist → Alpha → Beta → Paid</li>
+              <li>Waitlist to Alpha invite acceptance: 25–40%</li>
+              <li>Alpha activation (D7): ≥70% create 1st journal and 1st voice note</li>
+              <li>Alpha → Beta retention (D30): ≥35% WAU retention</li>
+              <li>Beta paid conversion (30 days): 15–25% to paid (starter tier)</li>
+              <li>Year-1 cumulative: 500–1,000 total users; 100+ paying subscribers</li>
+            </ul>
+
+            <h3>Activation events (Aha moments)</h3>
+            <ul>
+              <li>Record first voice note</li>
+              <li>Create first journal entry</li>
+              <li>Search &amp; find a memory successfully</li>
+              <li>Invite another family member and see a contribution</li>
+            </ul>
+
+            <h3>Channels &amp; Tactics</h3>
+            <h4>Owned / Product-led</h4>
+            <ul>
+              <li>Beehiiv waitlist &amp; newsletter (founder updates, memory prompts, behind-the-scenes progress).</li>
+              <li>In-app family invites (1-click SMS/email) with referral perks (e.g., +1 month, bonus storage).</li>
+              <li>“Story Chapter” share links (private by default) that nudge recipient sign-up.</li>
+            </ul>
+            <h4>Partnerships</h4>
+            <ul>
+              <li>Genealogy groups, local history societies, libraries.</li>
+              <li>Elder-care networks, hospice/grief counselors, estate planners (ethical, opt-in only).</li>
+              <li>Parenting communities, doulas, pediatric practices (resource bundle placement).</li>
+            </ul>
+            <h4>Creators &amp; Community</h4>
+            <ul>
+              <li>Memory preservation, parenting, and genealogy creators (YouTube/Instagram/TikTok) with sponsored demos and affiliate links.</li>
+              <li>Founders’ Council / private Discord for early families; showcase legit family stories (consent-based).</li>
+            </ul>
+            <h4>Paid Experiments (tight guardrails)</h4>
+            <ul>
+              <li>Lightweight tests on Meta/YouTube/Reddit targeting ICP interests.</li>
+              <li>Budget caps: start ~$50–$150/day/channel; kill underperformers &lt;7 days.</li>
+              <li>Measure first-week activation cost and paid conversion cost; scale only sub-target CAC.</li>
+            </ul>
+            <h4>PR / Earned</h4>
+            <ul>
+              <li>Founder story angles (legacy, privacy, posthumous storytelling).</li>
+              <li>Local + niche press (parenting, genealogy, digital privacy).</li>
+            </ul>
+
+            <h3>Launch Timeline (first 12 months)</h3>
+            <ul>
+              <li><strong>Months 0–2 (Foundation):</strong> Landing + waitlist live; 1,000+ waitlist target; memory-prompt email series.</li>
+              <li><strong>Months 3–4 (Private Alpha 25–50 families):</strong> Instrument activation events; D7≥70% activation; NPS≥40.</li>
+              <li><strong>Months 5–6 (Alpha Expand 75–150 families):</strong> Add family invites, search, and basic import; case-study capture.</li>
+              <li><strong>Months 7–8 (Invite-only Public Beta 200–500 users):</strong> Turn on billing; referral perks; first paid conversions.</li>
+              <li><strong>Months 9–10:</strong> Hit 100+ paying; refine onboarding; lock pricing tests.</li>
+              <li><strong>Months 11–12:</strong> Stabilize retention; investor metrics pack (activation, D30/D90, CAC/LTV), prep follow-on raise.</li>
+            </ul>
+
+            <h3>Pricing &amp; Packaging (tests)</h3>
+            <ul>
+              <li>Keep Free and $5 starter live at launch; introduce higher tiers later when advanced features land.</li>
+              <li>A/B: monthly vs. annual discount; family pack vs. add-on users; referral rewards vs. cash credits.</li>
+            </ul>
+
+            <h3>Metrics &amp; Instrumentation</h3>
+            <ul>
+              <li><strong>North Star:</strong> Weekly Capturing Families (WCF) — families with ≥1 capture event in last 7 days.</li>
+              <li><strong>Core KPIs:</strong> Activation rate (D7), D30/D90 retention, invite rate per active family, paid conversion 30/60 days, CAC, payback period, ARPU, churn.</li>
+              <li><strong>Event taxonomy:</strong> capture_voice, capture_journal, import_media, search_success, invite_sent, invite_accepted, subscription_started, export_requested.</li>
+              <li><strong>Stack:</strong> Privacy-respecting analytics; server-side events for billing; cohort dashboards.</li>
+            </ul>
+
+            <h3>Referral &amp; Advocacy</h3>
+            <ul>
+              <li>Give/Get: Referrer and referee each get +30 days on starter tier or storage credits.</li>
+              <li>Milestone badges (Founder, First 100 Families) and optional public showcase (opt-in only).</li>
+            </ul>
+
+            <h3>Risks &amp; Mitigations</h3>
+            <ul>
+              <li><strong>High CAC:</strong> Prioritize partnerships and creator affiliates; tighten audience targeting; ship referral boosts.</li>
+              <li><strong>Low activation:</strong> Shorten onboarding; default to voice capture first; celebrate first successful recall.</li>
+              <li><strong>Trust concerns:</strong> Publish privacy commitments plainly; add export-anytime and audit logs early; transparent roadmap.</li>
+              <li><strong>Channel fatigue:</strong> Rotate creatives around use cases (new baby, grandparent stories, family reunions).</li>
+            </ul>
           </div>
         </section>
         <section id="market-size-why-now" class="pitch-section">


### PR DESCRIPTION
## Summary
- add detailed go-to-market plan to the company pitch page

## Testing
- `npx --yes htmlhint full-pitch.html`

------
https://chatgpt.com/codex/tasks/task_e_68bcb79a6e64832eb141c8f5b7b15b09