### PR TITLE
Refactor go-to-market plan prose

### DIFF
--- a/full-pitch.html
+++ b/full-pitch.html
@@ -217,108 +217,37 @@
             <p>Prove demand, convert early families to paying subscribers, and build a durable acquisition flywheel—while protecting privacy and brand trust.</p>
 
             <h3>Ideal Customer Profiles (ICPs) &amp; Core Use Cases</h3>
-            <ul>
-              <li><strong>New parents &amp; expecting parents</strong> — capture voice notes, daily moments, milestones from birth onward.</li>
-              <li><strong>Family historians / genealogy-minded families</strong> — organize decades of photos, dates, and oral histories.</li>
-              <li><strong>Elder-care &amp; legacy planners</strong> — record stories/voices before they’re lost; enable posthumous releases.</li>
-              <li><strong>Multigenerational households</strong> — shared archive with roles/permissions (parents, teens, grandparents).</li>
-              <li><strong>Pet families (adjacent ICP)</strong> — journaling, photos, and voice tied to pets as part of family memory.</li>
-            </ul>
+            <p>New parents &amp; expecting parents capture voice notes, daily moments, and milestones from birth onward. Family historians / genealogy-minded families organize decades of photos, dates, and oral histories. Elder-care &amp; legacy planners record stories and voices before they’re lost and enable posthumous releases.</p>
+            <p>Multigenerational households maintain a shared archive with roles and permissions for parents, teens, and grandparents, and pet families (adjacent ICP) journal, photograph, and capture voice tied to pets as part of family memory.</p>
 
             <h3>Positioning &amp; Messaging Pillars</h3>
-            <ul>
-              <li><strong>Privacy-first, family-first.</strong> Your memories aren’t ad inventory. You own the archive.</li>
-              <li><strong>Effortless capture.</strong> Daily journaling + one-tap voice notes; low friction beats good intentions.</li>
-              <li><strong>Recall with meaning.</strong> Natural-language search and context, not just files.</li>
-              <li><strong>Built to last.</strong> Export anytime; future path to local HeirloomOS custody.</li>
-              <li><strong>Shared legacy.</strong> Multi-user by design; a single family story with many voices.</li>
-            </ul>
+            <p>Heirloom is privacy-first and family-first; your memories aren’t ad inventory and you own the archive. It enables effortless capture through daily journaling and one-tap voice notes where low friction beats good intentions, and delivers recall with meaning via natural-language search and context rather than files. Built to last with export anytime and a future path to local HeirloomOS custody, it creates a shared legacy that is multi-user by design so a single family story carries many voices.</p>
 
             <h3>Funnel &amp; Conversion Targets (Y1)</h3>
-            <ul>
-              <li>Waitlist → Alpha → Beta → Paid</li>
-              <li>Waitlist to Alpha invite acceptance: 25–40%</li>
-              <li>Alpha activation (D7): ≥70% create 1st journal and 1st voice note</li>
-              <li>Alpha → Beta retention (D30): ≥35% WAU retention</li>
-              <li>Beta paid conversion (30 days): 15–25% to paid (starter tier)</li>
-              <li>Year-1 cumulative: 500–1,000 total users; 100+ paying subscribers</li>
-            </ul>
-
-            <h3>Activation events (Aha moments)</h3>
-            <ul>
-              <li>Record first voice note</li>
-              <li>Create first journal entry</li>
-              <li>Search &amp; find a memory successfully</li>
-              <li>Invite another family member and see a contribution</li>
-            </ul>
+            <p>The year-one funnel moves families from Waitlist to Alpha to Beta to Paid, with Waitlist to Alpha invite acceptance at 25–40% and Alpha activation at D7 where at least 70% create a first journal and first voice note. Alpha to Beta retention at D30 aims for at least 35% WAU retention, and Beta paid conversion over 30 days targets 15–25% moving to the paid starter tier. Cumulatively, year one seeks 500–1,000 total users with 100+ paying subscribers.</p>
+            <p>Activation events include recording first voice note, creating first journal entry, searching and finding a memory successfully, inviting another family member and seeing a contribution.</p>
 
             <h3>Channels &amp; Tactics</h3>
-            <h4>Owned / Product-led</h4>
-            <ul>
-              <li>Beehiiv waitlist &amp; newsletter (founder updates, memory prompts, behind-the-scenes progress).</li>
-              <li>In-app family invites (1-click SMS/email) with referral perks (e.g., +1 month, bonus storage).</li>
-              <li>“Story Chapter” share links (private by default) that nudge recipient sign-up.</li>
-            </ul>
-            <h4>Partnerships</h4>
-            <ul>
-              <li>Genealogy groups, local history societies, libraries.</li>
-              <li>Elder-care networks, hospice/grief counselors, estate planners (ethical, opt-in only).</li>
-              <li>Parenting communities, doulas, pediatric practices (resource bundle placement).</li>
-            </ul>
-            <h4>Creators &amp; Community</h4>
-            <ul>
-              <li>Memory preservation, parenting, and genealogy creators (YouTube/Instagram/TikTok) with sponsored demos and affiliate links.</li>
-              <li>Founders’ Council / private Discord for early families; showcase legit family stories (consent-based).</li>
-            </ul>
-            <h4>Paid Experiments (tight guardrails)</h4>
-            <ul>
-              <li>Lightweight tests on Meta/YouTube/Reddit targeting ICP interests.</li>
-              <li>Budget caps: start ~$50–$150/day/channel; kill underperformers &lt;7 days.</li>
-              <li>Measure first-week activation cost and paid conversion cost; scale only sub-target CAC.</li>
-            </ul>
-            <h4>PR / Earned</h4>
-            <ul>
-              <li>Founder story angles (legacy, privacy, posthumous storytelling).</li>
-              <li>Local + niche press (parenting, genealogy, digital privacy).</li>
-            </ul>
+            <p><strong>Owned / Product-led.</strong> Beehiiv waitlist and newsletter deliver founder updates, memory prompts, and behind-the-scenes progress. In-app family invites offer one-click SMS or email with referral perks such as +1 month or bonus storage, and “Story Chapter” share links stay private by default while nudging recipients to sign up.</p>
+            <p><strong>Partnerships.</strong> Genealogy groups, local history societies, and libraries provide one avenue, complemented by elder-care networks, hospice and grief counselors, and estate planners on an ethical, opt-in basis, while parenting communities, doulas, and pediatric practices allow resource bundle placement.</p>
+            <p><strong>Creators &amp; Community.</strong> Memory preservation, parenting, and genealogy creators on YouTube, Instagram, and TikTok will feature sponsored demos and affiliate links, and a Founders’ Council with a private Discord for early families showcases legitimate family stories on a consent basis.</p>
+            <p><strong>Paid Experiments.</strong> Lightweight tests on Meta, YouTube, and Reddit target ICP interests with budget caps starting around $50–$150 per day per channel and underperformers cut in less than seven days, while measuring first-week activation cost and paid conversion cost so that only sub-target CAC efforts scale.</p>
+            <p><strong>PR / Earned.</strong> Founder story angles covering legacy, privacy, and posthumous storytelling alongside local and niche press in parenting, genealogy, and digital privacy drive earned attention.</p>
 
             <h3>Launch Timeline (first 12 months)</h3>
-            <ul>
-              <li><strong>Months 0–2 (Foundation):</strong> Landing + waitlist live; 1,000+ waitlist target; memory-prompt email series.</li>
-              <li><strong>Months 3–4 (Private Alpha 25–50 families):</strong> Instrument activation events; D7≥70% activation; NPS≥40.</li>
-              <li><strong>Months 5–6 (Alpha Expand 75–150 families):</strong> Add family invites, search, and basic import; case-study capture.</li>
-              <li><strong>Months 7–8 (Invite-only Public Beta 200–500 users):</strong> Turn on billing; referral perks; first paid conversions.</li>
-              <li><strong>Months 9–10:</strong> Hit 100+ paying; refine onboarding; lock pricing tests.</li>
-              <li><strong>Months 11–12:</strong> Stabilize retention; investor metrics pack (activation, D30/D90, CAC/LTV), prep follow-on raise.</li>
-            </ul>
+            <p>Months 0–2 lay the foundation with landing and waitlist live, a 1,000+ waitlist target, and a memory-prompt email series; Months 3–4 run a private Alpha with 25–50 families, instrument activation events, achieve D7≥70% activation, and NPS≥40; Months 5–6 expand Alpha to 75–150 families with family invites, search, basic import, and case-study capture; Months 7–8 host an invite-only Public Beta for 200–500 users, turn on billing, add referral perks, and secure the first paid conversions; Months 9–10 aim to hit 100+ paying, refine onboarding, and lock pricing tests; Months 11–12 stabilize retention and assemble an investor metrics pack covering activation, D30/D90, CAC/LTV, while preparing a follow-on raise.</p>
 
             <h3>Pricing &amp; Packaging (tests)</h3>
-            <ul>
-              <li>Keep Free and $5 starter live at launch; introduce higher tiers later when advanced features land.</li>
-              <li>A/B: monthly vs. annual discount; family pack vs. add-on users; referral rewards vs. cash credits.</li>
-            </ul>
+            <p>Heirloom will keep Free and $5 starter tiers live at launch and introduce higher tiers later when advanced features land, while A/B testing monthly versus annual discount, family pack versus add-on users, and referral rewards versus cash credits.</p>
 
             <h3>Metrics &amp; Instrumentation</h3>
-            <ul>
-              <li><strong>North Star:</strong> Weekly Capturing Families (WCF) — families with ≥1 capture event in last 7 days.</li>
-              <li><strong>Core KPIs:</strong> Activation rate (D7), D30/D90 retention, invite rate per active family, paid conversion 30/60 days, CAC, payback period, ARPU, churn.</li>
-              <li><strong>Event taxonomy:</strong> capture_voice, capture_journal, import_media, search_success, invite_sent, invite_accepted, subscription_started, export_requested.</li>
-              <li><strong>Stack:</strong> Privacy-respecting analytics; server-side events for billing; cohort dashboards.</li>
-            </ul>
+            <p>The North Star is Weekly Capturing Families (WCF), defined as families with ≥1 capture event in the last seven days. Core KPIs span activation rate at D7, D30/D90 retention, invite rate per active family, paid conversion at 30 and 60 days, CAC, payback period, ARPU, and churn. Event taxonomy includes capture_voice, capture_journal, import_media, search_success, invite_sent, invite_accepted, subscription_started, and export_requested, and the stack uses privacy-respecting analytics, server-side events for billing, and cohort dashboards.</p>
 
             <h3>Referral &amp; Advocacy</h3>
-            <ul>
-              <li>Give/Get: Referrer and referee each get +30 days on starter tier or storage credits.</li>
-              <li>Milestone badges (Founder, First 100 Families) and optional public showcase (opt-in only).</li>
-            </ul>
+            <p>Give/Get ensures the referrer and referee each receive +30 days on the starter tier or storage credits, and milestone badges such as Founder and First 100 Families with an optional public showcase offer additional advocacy.</p>
 
             <h3>Risks &amp; Mitigations</h3>
-            <ul>
-              <li><strong>High CAC:</strong> Prioritize partnerships and creator affiliates; tighten audience targeting; ship referral boosts.</li>
-              <li><strong>Low activation:</strong> Shorten onboarding; default to voice capture first; celebrate first successful recall.</li>
-              <li><strong>Trust concerns:</strong> Publish privacy commitments plainly; add export-anytime and audit logs early; transparent roadmap.</li>
-              <li><strong>Channel fatigue:</strong> Rotate creatives around use cases (new baby, grandparent stories, family reunions).</li>
-            </ul>
+            <p>High CAC is mitigated by prioritizing partnerships and creator affiliates, tightening audience targeting, and shipping referral boosts. Low activation will be addressed by shortening onboarding, defaulting to voice capture first, and celebrating the first successful recall. Trust concerns require publishing privacy commitments plainly, adding export-anytime and audit logs early, and maintaining a transparent roadmap. To avoid channel fatigue, creatives will rotate around use cases such as new baby, grandparent stories, and family reunions.</p>
           </div>
         </section>
         <section id="market-size-why-now" class="pitch-section">


### PR DESCRIPTION
## Summary
- Rewrite Go-to-Market Plan section in narrative style, replacing lists with short paragraphs.
- Preserve all metrics and timelines while weaving ICPs, channels, and risk mitigations into cohesive prose.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcba84a8ac832e926ec9388846ec61