### PR TITLE
Add roadmap and dated milestones to company pitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- add Roadmap & Dated Milestones section to company pitch
 - add 36-Month Financial Model section to company pitch
 - add Unit Economics & Pricing detail to company pitch
 - remove `About` and `Investor Info` links from all headers and footers

--- a/full-pitch.html
+++ b/full-pitch.html
@@ -382,7 +382,40 @@
           <p class="overline">Section</p>
           <h2>Roadmap & Dated Milestones</h2>
           <div class="section-body">
-            <!-- INSERT VERBATIM TEXT HERE LATER -->
+            <p>This roadmap sequences product, trust, and growth work across thirty-six months with explicit gates. Dates are expressed as month ranges from funding close; each phase includes clear exit criteria so spend scales only when the underlying signals are in range.</p>
+            <h3>Months 0–2 — Foundation</h3>
+            <p>The public landing page and waitlist go live with a target of 1,000+ sign-ups. Core capture flows (journal, voice, photo/video) are implemented alongside export-anytime, basic search, and family roles/permissions. Privacy policy, sub-processor list, and data-lifecycle docs are published. Analytics is instrumented for D7 activation, D30/D90 retention, invite rate, Free→Paid conversion, and gross margin by plan.</p>
+            <p><strong>Exit criteria:</strong> stable capture success rate ≥99%, waitlist ≥1,000, export flow verified end-to-end.</p>
+            <h3>Months 3–4 — Private Alpha (25–50 families)</h3>
+            <p>The focus is activation quality, not volume. Families record a first voice note and first journal entry within the first week; natural-language search returns a relevant result; at least one additional family member is invited and contributes.</p>
+            <p><strong>Exit criteria:</strong> waitlist→alpha acceptance 25–40%, D7 activation ≥70%, D30 WAU retention ≥35%, NPS ≥40, zero P0 security issues.</p>
+            <h3>Months 5–6 — Alpha Expansion (75–150 families)</h3>
+            <p>Family invites, search improvements, and basic imports go live. Reliability work hardens ingest/transcode pipelines; audit logs and device/session management ship. Case studies (with consent) are captured to showcase the “capture → recall → share” loop.</p>
+            <p><strong>Exit criteria:</strong> sustained activation/retention at alpha levels, import success rate ≥98%, first export/restore drill passed.</p>
+            <h3>Months 7–8 — Invite-Only Public Beta (200–500 users)</h3>
+            <p>Billing turns on for the Free and $5 starter tiers; referral perks are enabled. Channel tests begin across creator affiliates and partnerships with strict CAC caps.</p>
+            <p><strong>Exit criteria:</strong> 15–25% paid conversion within 30 days for beta cohorts, blended starter-tier gross margin ≥70%, CAC payback &lt;6 months on gross profit in at least one scalable channel.</p>
+            <h3>Months 9–10 — Monetization & Onboarding Maturation</h3>
+            <p>Pricing experiments (monthly vs. annual discount) are run and locked; onboarding is shortened with default voice capture first.</p>
+            <p><strong>Exit criteria:</strong> 100+ paying subscribers cumulative, churn stabilizing below modeled thresholds, support load within targets.</p>
+            <h3>Months 11–12 — Readiness & Raise</h3>
+            <p>Retention stabilizes; the investor metrics pack (activation, D30/D90, CAC/LTV, gross margin by plan) is published. SOC 2 Type I prep completes (controls in place, audit scheduled).</p>
+            <p><strong>Exit criteria:</strong> 500–1,000 total users, 100+ paying, evidence of one repeatable acquisition channel, cash runway plan for the next stage.</p>
+            <h3>Months 13–18 — Product Depth & Trust</h3>
+            <p>AI storytelling v1 ships (on-demand chapters assembled from family entries); genealogy linkage and richer imports are added. Content-scoped vector search is productionized; privacy posture is reiterated with clearer consent controls. SOC 2 Type I completes; coordinated vuln disclosure program is formalized.</p>
+            <p><strong>Exit criteria:</strong> 1,000+ paying or a clear trajectory there, blended gross margin trending toward 75–80%, LTV/CAC ≥3.0 over rolling 3-month windows.</p>
+            <h3>Months 19–24 — Scale the Base</h3>
+            <p>Partnerships with genealogy groups, libraries, and elder-care networks expand; creator affiliates are scaled where CAC stays inside guardrails. Mobile offline capture and multilingual UI/localization launch in priority markets.</p>
+            <p><strong>Exit criteria:</strong> 5,000+ total users with ≥1,000 paying; annual plans and family packs contribute measurable ARPU uplift; operational SLOs (capture/recall latency) hold under load.</p>
+            <h3>Months 25–30 — HeirloomOS Engineering Validation</h3>
+            <p>Hardware prototypes (EVT/DVT) are built with local-first encrypted storage, on-device search/narrative models, and LAN/offline access. A pilot with 50–200 households runs on contribution-positive economics (materials/assembly/support covered).</p>
+            <p><strong>Exit criteria:</strong> pilot NPS ≥50, seamless cloud↔local migration, no critical data-loss incidents, preorder interest validated without overcommitting inventory.</p>
+            <h3>Months 31–36 — Dual-Curve Execution</h3>
+            <p>A limited HeirloomOS run is offered by preorder while SaaS growth continues; cloud remains a complete standalone product for families not ready for hardware. Internationalization and accessibility deepen; export/restore drills become routine.</p>
+            <p><strong>Exit criteria:</strong> tens of thousands of total users, 5,000–10,000 paying (moderate case) with ARPU uplift from annuals/family packs, hardware units contribution-positive with tight inventory turns, cash discipline maintained (spend gated by margin and CAC payback).</p>
+            <h3>Gating & Contingencies</h3>
+            <p>Any phase that misses activation, retention, margin, or CAC payback gates triggers a spending ratchet down and a return to product fundamentals (capture friction, recall quality, trust messaging) before resuming scale work. Over-performance unlocks measured increases in creator and partnership budgets, never at the expense of privacy or exportability.</p>
+            <p>This timeline is deliberately conservative: ship the core, prove behavior, earn revenue, and then widen the surface area. The result is a business that compounds through usage and trust rather than hype or lock-in.</p>
           </div>
         </section>
         <section id="legal-ip" class="pitch-section">


### PR DESCRIPTION
## Summary
- insert 36-month roadmap and milestones into pitch
- document change in project changelog

## Testing
- `npm test` *(fails: Could not read package.json: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68bcd76dd1c0832e92f87f869eb7a960