### PR TITLE
Add Customer Support & Accessibility section to company pitch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 
+- add Customer Support & Accessibility section to company pitch
 - add Roadmap & Dated Milestones section to company pitch
 - add 36-Month Financial Model section to company pitch
 - add Unit Economics & Pricing detail to company pitch

--- a/full-pitch.html
+++ b/full-pitch.html
@@ -448,7 +448,28 @@
           <p class="overline">Section</p>
           <h2>Customer Support & Accessibility</h2>
           <div class="section-body">
-            <!-- INSERT VERBATIM TEXT HERE LATER -->
+            <p>Heirloom treats support as part of the product, not an afterthought. Families entrust us with irreplaceable memories; the service must feel dependable and human. Support operations begin lean and disciplined, with the same privacy-first posture that governs the product itself.</p>
+            <h3>Support policy and hours</h3>
+            <p>Email and in-app messaging are the primary channels at launch, backed by a public help center with step-by-step guides, short videos, and a transparent status page. First-response targets are within one business day for standard inquiries and within two business hours for high-severity incidents during business hours. Weekend coverage is best-effort, with clear handoffs when an issue requires engineering. Every sensitive request (exports, deletions, account recovery) follows an auditable workflow.</p>
+            <h3>Scope of assistance</h3>
+            <p>The team prioritizes moments that matter: getting started, capturing voice and journals, importing past media, restoring access, and exporting archives. For minors’ accounts and legacy scenarios, guardianship and posthumous release requests are verified and tracked with least-privilege access and full audit logs. Support can view only the minimum necessary metadata to troubleshoot; content is never inspected without explicit, revocable consent.</p>
+            <h3>Self-serve and onboarding</h3>
+            <p>A guided first-run flow, contextual tips, and a living knowledge base reduce support load while improving time-to-value. Memory prompts and “first recall” tutorials help families experience the core loop quickly—capture, find, and share—so they don’t stall at setup. Proactive check-ins go to early cohorts to catch friction before it becomes churn.</p>
+            <h3>Service levels for paid plans</h3>
+            <p>Subscribers receive prioritized queues and documented targets for first response and follow-up cadence. Incident communications are plain-language and timestamped, with root-cause summaries published after resolution. Credits are reserved for material, subscriber-impacting downtime according to posted terms.</p>
+            <h3>Accessibility commitments</h3>
+            <p>The interface targets WCAG 2.2 AA from the start: semantic HTML, keyboard navigability, visible focus states, sufficient color contrast, and screen-reader-friendly labels and landmarks. Media features include automatic transcripts for voice notes, captions for videos, and adjustable playback speed. Reading comfort is supported with scalable type, a reduced-motion mode that honors system settings, and high-contrast themes. Forms avoid timeouts without warning, and error messages are descriptive rather than cryptic.</p>
+            <h3>Inclusive design for families</h3>
+            <p>Roles and permissions are readable and predictable for non-technical users; actions like “share,” “download,” and “make private” use consistent language and confirmation. Age-appropriate defaults protect minors by design. Names, dates, and calendars localize to the family’s settings; the product accommodates multiple surnames, non-Latin scripts, and right-to-left layouts as localization rolls out.</p>
+            <h3>Internationalization and language</h3>
+            <p>English ships first, with a localization pipeline prepared for additional languages as demand concentrates (starting with Spanish and French). Transcripts and captions respect the capture language; cross-language search is on the roadmap once quality meets bar. Time zones and regional formats are stored canonically and displayed per user preference.</p>
+            <h3>Abuse, safety, and takedowns</h3>
+            <p>A clear in-product “Report” control routes to a documented process for abuse, fraud, or illegal content. DMCA requests and counter-notices are handled promptly by a designated agent. Public-share links (when enabled) are rate-limited, revocable, and never embed third-party trackers.</p>
+            <h3>Data rights through support</h3>
+            <p>GDPR/CCPA requests—access, export, rectification, deletion—are supported via self-serve flows and assisted by support when needed. Exports are delivered in open formats with checksums; deletion requests propagate to backups on a published schedule and are confirmed when complete.</p>
+            <h3>Measuring quality</h3>
+            <p>Support health is tracked with first-response time, time-to-resolution, CSAT, and reopen rate, alongside product SLOs for capture success, indexing latency, and recall time. Insights from tickets feed directly into roadmap fixes and help-center updates.</p>
+            <p>The standard is simple: families should feel seen, understood, and in control—able to get help quickly, to use the product with or without a mouse, to read and hear their memories in the ways that work for them, and to leave with everything intact if they ever choose to.</p>
           </div>
         </section>
         <section id="appendices" class="pitch-section">


### PR DESCRIPTION
## Summary
- add detailed customer support policy, service levels, and accessibility commitments to the pitch
- document addition in changelog

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcda80801c832e8ac72f20efb91c15