### PR TITLE
Add Gamma embed to investor pitch deck page

### DIFF
--- a/investorinfo/index.html
+++ b/investorinfo/index.html
@@ -41,7 +41,7 @@
     <div class="grid" style="margin-top:2rem;">
       <a class="card" href="one-pager.html" style="padding:1rem; border:1px solid var(--border); border-radius:18px; background:var(--bg-elev);">One-Page Pitch</a>
       <a class="card" href="/full-pitch.html" style="padding:1rem; border:1px solid var(--border); border-radius:18px; background:var(--bg-elev);">Full Pitch</a>
-      <a class="card" href="deck.html" style="padding:1rem; border:1px solid var(--border); border-radius:18px; background:var(--bg-elev);">Pitch Deck</a>
+      <a class="card" href="pitch-deck.html" style="padding:1rem; border:1px solid var(--border); border-radius:18px; background:var(--bg-elev);">Pitch Deck</a>
       <a class="card" href="demo.html" style="padding:1rem; border:1px solid var(--border); border-radius:18px; background:var(--bg-elev);">Demo</a>
       <a class="card" href="team.html" style="padding:1rem; border:1px solid var(--border); border-radius:18px; background:var(--bg-elev);">Team</a>
     </div>

--- a/investorinfo/pitch-deck.html
+++ b/investorinfo/pitch-deck.html
@@ -14,7 +14,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Pitch Deck — Heirloom</title>
   <meta name="description" content="Pitch deck viewer."/>
-  <link rel="canonical" href="https://www.tryheirloomai.com/investorinfo/deck.html">
+  <link rel="canonical" href="https://www.tryheirloomai.com/investorinfo/pitch-deck.html">
   <meta property="og:title" content="Pitch Deck — Heirloom">
   <meta property="og:description" content="Pitch deck viewer.">
   <meta property="og:image" content="/assets/hero.jpg">
@@ -37,10 +37,9 @@
 <main>
   <section class="hero" style="padding-top:4rem;">
     <h1>Pitch Deck</h1>
-    <div class="card" style="margin-top:1rem; padding:1rem; border:1px solid var(--border); border-radius:18px; background:var(--bg-elev);">
-      <p>Drop latest deck.pdf here</p>
-      <iframe src="/assets/Heirloom-Pitch-Deck.pdf" style="width:100%; height:500px; border:1px solid var(--border); border-radius:12px;" title="Pitch Deck"></iframe>
-      <p><a href="/assets/Heirloom-Pitch-Deck.pdf" target="_blank">View full screen</a></p>
+    <div style="max-width:900px; margin-inline:auto; padding:24px 16px;">
+      <iframe src="https://gamma.app/embed/stvn9kj0n5dff1k" style="width: 700px; max-width: 100%; height: 450px" allow="fullscreen" title="Heirloom: Preserving Family Stories Forever"></iframe>
+      <noscript><p><a href="https://gamma.app/embed/stvn9kj0n5dff1k" target="_blank" rel="noopener">View the pitch deck</a></p></noscript>
     </div>
   </section>
 </main>


### PR DESCRIPTION
## Summary
- rename deck.html to pitch-deck.html and embed Gamma deck
- update investor info index link to new pitch-deck page

## Testing
- `npx -y html-validate investorinfo/pitch-deck.html investorinfo/index.html` *(fails: DOCTYPE not uppercase, void-style, no-inline-style etc)*

------
https://chatgpt.com/codex/tasks/task_e_68bce6d1da00832e961e8c2f72bdfa07