### PR TITLE
feat: add about copy and homepage pillars

### DIFF
--- a/HomeHeirloomBlock.html
+++ b/HomeHeirloomBlock.html
@@ -1,0 +1,27 @@
+<section class="home-heirloom-block about-section">
+  <h2>Capture today. Preserve for tomorrow. Live on forever.</h2>
+  <p class="lede">Heirloom is a private home for your words, your voice, and your videos—built so your memories can outlast you.</p>
+  <div class="cta-strip cta-links">
+    <a href="/roadmap.html">View the Roadmap</a>
+    <a href="/waitlist.html">Join the Waitlist</a>
+  </div>
+  <div class="grid pillars" style="margin-top:2rem;">
+    <div>
+      <h3>Capture</h3>
+      <p>Journaling, voice notes with transcription, and video uploads.</p>
+    </div>
+    <div>
+      <h3>Preserve</h3>
+      <p>Private by default, clean timeline, export &amp; backup options.</p>
+    </div>
+    <div>
+      <h3>Recall</h3>
+      <p>Search by date/keyword/mood; AI-powered recall and Life Story Chapters.</p>
+    </div>
+    <div>
+      <h3>Legacy</h3>
+      <p><strong>Talk to Me</strong> conversations in your own voice, Genealogy Mode, and Posthumous Release.</p>
+    </div>
+  </div>
+  <p style="margin-top:1.5rem;">Free tier includes targeted ads; premium tiers are ad-free.</p>
+</section>

--- a/README_UPDATE.md
+++ b/README_UPDATE.md
@@ -1,0 +1,6 @@
+# Update Notes
+
+- **about.md** and **about.html** contain the full About page copy and markup.
+- **HomeHeirloomBlock.html** holds the reusable homepage hero and four-pillar block. It is included in `index.html`.
+- **waitlist.html** provides a placeholder page for the waitlist signup.
+- To edit these sections, modify the corresponding files directly; the site has no build step.

--- a/about.html
+++ b/about.html
@@ -12,11 +12,11 @@
   </script>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>About Heirloom | Private journaling and voice capture</title>
-  <meta name="description" content="About Heirloom—private journaling and voice capture built for decades.">
-  <link rel="canonical" href="https://www.tryheirloomai.com/about.html">
-  <meta property="og:title" content="About Heirloom | Private journaling and voice capture">
-  <meta property="og:description" content="About Heirloom—private journaling and voice capture built for decades.">
+  <title>About Heirloom — Capture, Preserve, Recall, and Legacy</title>
+  <meta name="description" content="Heirloom is a private, long-term archive for your words, voice, and videos—with AI recall, Life Story Chapters, and “Talk to Me” conversations so your presence can live on. Free tier includes targeted ads; premium tiers are ad-free.">
+  <link rel="canonical" href="https://www.tryheirloomai.com/about">
+  <meta property="og:title" content="About Heirloom — Capture, Preserve, Recall, and Legacy">
+  <meta property="og:description" content="Heirloom is a private, long-term archive for your words, voice, and videos—with AI recall, Life Story Chapters, and “Talk to Me” conversations so your presence can live on. Free tier includes targeted ads; premium tiers are ad-free.">
   <meta property="og:image" content="/assets/hero.jpg">
   <meta name="twitter:card" content="summary_large_image">
   <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
@@ -38,82 +38,97 @@
     <section class="about-hero">
       <img src="/assets/logo.svg" alt="Heirloom brand mark">
       <h1>About Heirloom</h1>
-      <p class="lede">Build a living archive of your life—one entry, one voice note at a time.</p>
-      <p>Heirloom helps you capture daily thoughts, speak your memories out loud, and keep them safe for the people who matter. Private by default. Built for decades.</p>
+      <h2>Capture today. Preserve for tomorrow. Live on forever.</h2>
+      <p>Heirloom helps you record the moments of your life—your words, your voice, your videos—and keep them safe for the people who matter most. Private by default. Built for decades, not trends.</p>
     </section>
 
-    <section class="about-section" id="story">
+    <section class="about-section">
       <h2>Why we’re building Heirloom</h2>
-      <p>Some memories vanish in tiny ways—the sound of a laugh, the way someone told a story. Heirloom began as a promise to hold on to those details before they fade. We’re building a simple, durable place to put your days: words you’ve written, thoughts you’ve spoken, moments you don’t want to lose. Not a feed. Not a trend. A home for what matters across a lifetime.</p>
+      <p>Memories don’t disappear all at once—they slip away in small details: the sound of a laugh, the way someone told a story, the look in a moment you didn’t think to save.</p>
+      <p>Heirloom began as a promise: to build a durable, private place for those details. Not a feed. Not a trend. A living archive of your life—something you can return to and something your family can hold on to, even after you’re gone.</p>
     </section>
 
-    <section class="about-section" id="what-is">
-      <h2>What is Heirloom?</h2>
-      <p>Heirloom is a private, long-term memory home. Start with journaling and voice notes.</p>
-      <p>Over time, your entries stack into a clear, searchable record of your life—something you can return to, share selectively, and preserve.</p>
-    </section>
-
-    <section class="about-section" id="focus">
-      <h2>What we’re building first</h2>
-      <p>In our first year, we’re focused on doing a few things exceptionally well:</p>
+    <section class="about-section">
+      <h2>How Heirloom works</h2>
+      <p>We’ve designed Heirloom around four pillars:</p>
+      <h3>1. Capture</h3>
       <ul>
-        <li>Journaling: Write daily entries with timestamps.</li>
-        <li>Voice capture: Record voice notes; automatic transcription.</li>
-        <li>Private by default: Your data stays yours.</li>
-        <li>Clean timeline: See your days stack into a life.</li>
-        <li>Export-ready foundation: Laying groundwork for local backups.</li>
+        <li><strong>Journaling</strong> – Write daily entries with timestamps.</li>
+        <li><strong>Voice Notes</strong> – Record your voice; we transcribe and save both text and audio.</li>
+        <li><strong>Video Uploads</strong> – Add personal videos alongside your stories.</li>
+        <li><strong>Daily Prompts</strong> – Gentle nudges to help capture moments you might otherwise miss.</li>
       </ul>
-      <p>These are the core stones of our first year.</p>
+      <h3>2. Preserve</h3>
+      <ul>
+        <li><strong>Private by Default</strong> – You control who sees what.</li>
+        <li><strong>Clean Timeline</strong> – Watch your days stack into a clear record of your life.</li>
+        <li><strong>Export &amp; Backup</strong> – Practical options so your data is never trapped.</li>
+      </ul>
+      <h3>3. Recall</h3>
+      <ul>
+        <li><strong>Searchable Memories</strong> – Find entries by date, keyword, or mood.</li>
+        <li><strong>AI-Powered Recall (coming soon)</strong> – Ask in plain language: <em>“What did Dad sound like when I was 10?”</em> or <em>“Show me every video from our first house.”</em></li>
+        <li><strong>Life Story Chapters</strong> – With enough entries, Heirloom weaves your memories into multi-chapter narratives—your life told back to you like a book.</li>
+      </ul>
+      <h3>4. Legacy</h3>
+      <ul>
+        <li><strong>Talk to Me</strong> – Over years, Heirloom learns your voice and your personality. Long after you’re gone, your loved ones can ask you questions, carry on conversations, or hear you read your grandchildren a bedtime story in your own voice.</li>
+        <li><strong>Genealogy Mode</strong> – Connect family trees so your memories link with the generations before and after you.</li>
+        <li><strong>Posthumous Release</strong> – Share messages, videos, or life chapters on your terms, even after death.</li>
+      </ul>
     </section>
 
-    <section class="about-section" id="how">
-      <h2>How it works</h2>
-      <p>Sign in and you’re on your timeline. Write a journal entry or tap record to speak a thought out loud.</p>
-      <p>We transcribe your voice note and keep the audio. Entries are organized by day so you can skim your timeline. Early search lets you pull up moments by date or keyword.</p>
-      <p>As we iterate, search and export options will expand—carefully, with privacy as the guiding rule.</p>
+    <section class="about-section">
+      <h2>Privacy first. Longevity always.</h2>
+      <p>Your data is your story. We build Heirloom with four core principles:</p>
+      <ul>
+        <li><strong>Privacy-first design</strong> – You decide what’s shared and what stays private.</li>
+        <li><strong>Ad model transparency</strong> – Free tier includes ads, including targeted ads; premium tiers are ad-free.</li>
+        <li><strong>Export-ready</strong> – Your data can always be backed up or moved.</li>
+        <li><strong>Longevity-focused</strong> – Optimized for decades, not product cycles.</li>
+      </ul>
     </section>
 
-    <section class="about-section" id="privacy">
-      <h2>Privacy first. Your stories, your rules.</h2>
-      <p>Your data is your story. We’re building Heirloom with a privacy-first mindset: no ad targeting, transparent processing, and practical export options so you’re never trapped.</p>
-      <p>Longevity matters; we’re optimizing for decades, not quarters. Local-first foundations guide our future so your memories remain under your control.</p>
-    </section>
-
-    <section class="about-section" id="roadmap">
+    <section class="about-section">
       <h2>What’s next</h2>
-      <p>Curious what’s next? See our <a href="/roadmap.html">public roadmap</a> for the next 12 months.</p>
+      <p>We’re building toward the first release focused on journaling, voice capture, and video uploads within the next 12 months. From there, we’ll carefully expand features, guided by privacy and durability.</p>
+      <p>Check the public roadmap to follow our progress.</p>
     </section>
 
-    <section class="about-section" id="team">
-      <h2>The people behind Heirloom</h2>
-      <p>We’re a small team of builders, designers, and patient testers who care about reliability and longevity. No resumes, just humans working to keep memories safe and meaningful for the long haul.</p>
+    <section class="about-section">
+      <h2>The person behind Heirloom</h2>
+      <p>Heirloom isn’t the work of a big team. It began with one founder—me—driven by the need to keep family voices and stories alive before they were lost.</p>
+      <p>Right now, I’m designing, coding, and testing every part of it myself. But Heirloom isn’t meant to stay a solo effort. I’m open to partners and contributors who share the belief that our lives deserve to be remembered across generations.</p>
+      <p>This project is personal—but it’s built to become something bigger than me.</p>
     </section>
 
-    <section class="about-section" id="faq">
+    <section class="about-section">
       <h2>FAQ</h2>
       <dl>
         <div>
           <dt>When can I try it?</dt>
-          <dd>We’re building toward the first release focused on journaling and voice capture within the next 12 months; check the roadmap.</dd>
+          <dd>We’re building toward the first release within 12 months. It will focus on journaling, voice capture, and video uploads.</dd>
         </div>
         <div>
           <dt>Will my data be private?</dt>
-          <dd>Yes, privacy is core; more on export and backups as we progress.</dd>
+          <dd>Yes. You control what’s shared. Free tier includes targeted ads; premium tiers remove them. Export and backup options are built in from the start.</dd>
         </div>
         <div>
           <dt>Will there be mobile?</dt>
-          <dd>We’re building web-first; mobile access and flows are a priority as we approach release.</dd>
+          <dd>We’re building web-first, with mobile access a priority before release.</dd>
         </div>
         <div>
           <dt>How do I follow progress?</dt>
-          <dd>Keep an eye on the <a href="/roadmap.html">roadmap</a> and any dev updates or newsletter already present.</dd>
+          <dd>Check our roadmap or sign up for early updates to know when key milestones are hit.</dd>
         </div>
       </dl>
     </section>
 
-    <section class="about-cta">
-      <p>Want updates and early access when we hit key milestones?</p>
-      <a href="/#waitlist" class="join-waitlist">Join the waitlist</a>
+    <section class="about-section">
+      <div class="cta-strip cta-links">
+        <a href="/roadmap.html">View the Roadmap</a>
+        <a href="/waitlist.html">Join the Waitlist</a>
+      </div>
     </section>
   </article>
 </main>

--- a/about.md
+++ b/about.md
@@ -1,0 +1,87 @@
+# About Heirloom  
+
+### Capture today. Preserve for tomorrow. Live on forever.  
+
+Heirloom helps you record the moments of your life—your words, your voice, your videos—and keep them safe for the people who matter most. Private by default. Built for decades, not trends.  
+
+---
+
+## Why we’re building Heirloom  
+Memories don’t disappear all at once—they slip away in small details: the sound of a laugh, the way someone told a story, the look in a moment you didn’t think to save.  
+
+Heirloom began as a promise: to build a durable, private place for those details. Not a feed. Not a trend. A living archive of your life—something you can return to and something your family can hold on to, even after you’re gone.  
+
+---
+
+## How Heirloom works  
+We’ve designed Heirloom around four pillars:  
+
+### 1. Capture  
+- **Journaling** – Write daily entries with timestamps.  
+- **Voice Notes** – Record your voice; we transcribe and save both text and audio.  
+- **Video Uploads** – Add personal videos alongside your stories.  
+- **Daily Prompts** – Gentle nudges to help capture moments you might otherwise miss.  
+
+### 2. Preserve  
+- **Private by Default** – You control who sees what.  
+- **Clean Timeline** – Watch your days stack into a clear record of your life.  
+- **Export & Backup** – Practical options so your data is never trapped.  
+
+### 3. Recall  
+- **Searchable Memories** – Find entries by date, keyword, or mood.  
+- **AI-Powered Recall (coming soon)** – Ask in plain language: *“What did Dad sound like when I was 10?”* or *“Show me every video from our first house.”*  
+- **Life Story Chapters** – With enough entries, Heirloom weaves your memories into multi-chapter narratives—your life told back to you like a book.  
+
+### 4. Legacy  
+- **Talk to Me** – Over years, Heirloom learns your voice and your personality. Long after you’re gone, your loved ones can ask you questions, carry on conversations, or hear you read your grandchildren a bedtime story in your own voice.  
+- **Genealogy Mode** – Connect family trees so your memories link with the generations before and after you.  
+- **Posthumous Release** – Share messages, videos, or life chapters on your terms, even after death.  
+
+---
+
+## Privacy first. Longevity always.  
+Your data is your story. We build Heirloom with four core principles:  
+
+- **Privacy-first design** – You decide what’s shared and what stays private.  
+- **Ad model transparency** – Free tier includes ads, including targeted ads; premium tiers are ad-free.  
+- **Export-ready** – Your data can always be backed up or moved.  
+- **Longevity-focused** – Optimized for decades, not product cycles.  
+
+---
+
+## What’s next  
+We’re building toward the first release focused on journaling, voice capture, and video uploads within the next 12 months. From there, we’ll carefully expand features, guided by privacy and durability.  
+
+Check the public roadmap to follow our progress.  
+
+---
+
+## The person behind Heirloom  
+Heirloom isn’t the work of a big team. It began with one founder—me—driven by the need to keep family voices and stories alive before they were lost.  
+
+Right now, I’m designing, coding, and testing every part of it myself. But Heirloom isn’t meant to stay a solo effort. I’m open to partners and contributors who share the belief that our lives deserve to be remembered across generations.  
+
+This project is personal—but it’s built to become something bigger than me.  
+
+---
+
+## FAQ  
+
+**When can I try it?**  
+We’re building toward the first release within 12 months. It will focus on journaling, voice capture, and video uploads.  
+
+**Will my data be private?**  
+Yes. You control what’s shared. Free tier includes targeted ads; premium tiers remove them. Export and backup options are built in from the start.  
+
+**Will there be mobile?**  
+We’re building web-first, with mobile access a priority before release.  
+
+**How do I follow progress?**  
+Check our roadmap or sign up for early updates to know when key milestones are hit.  
+
+---
+
+### CTA ROW (both pages)
+- **View the Roadmap** → /roadmap
+- **Join the Waitlist** → /waitlist
+

--- a/index.html
+++ b/index.html
@@ -39,6 +39,34 @@
     <h1>Heirloom — Your Family’s Living Memory</h1>
     <p>Capture life, remember everything, and pass it on—private by design.</p>
   </section>
+  <!-- HomeHeirloomBlock -->
+  <section class="home-heirloom-block about-section">
+    <h2>Capture today. Preserve for tomorrow. Live on forever.</h2>
+    <p class="lede">Heirloom is a private home for your words, your voice, and your videos—built so your memories can outlast you.</p>
+    <div class="cta-strip cta-links">
+      <a href="/roadmap.html">View the Roadmap</a>
+      <a href="/waitlist.html">Join the Waitlist</a>
+    </div>
+    <div class="grid pillars" style="margin-top:2rem;">
+      <div>
+        <h3>Capture</h3>
+        <p>Journaling, voice notes with transcription, and video uploads.</p>
+      </div>
+      <div>
+        <h3>Preserve</h3>
+        <p>Private by default, clean timeline, export &amp; backup options.</p>
+      </div>
+      <div>
+        <h3>Recall</h3>
+        <p>Search by date/keyword/mood; AI-powered recall and Life Story Chapters.</p>
+      </div>
+      <div>
+        <h3>Legacy</h3>
+        <p><strong>Talk to Me</strong> conversations in your own voice, Genealogy Mode, and Posthumous Release.</p>
+      </div>
+    </div>
+    <p style="margin-top:1.5rem;">Free tier includes targeted ads; premium tiers are ad-free.</p>
+  </section>
   <section class="tiles">
     <div class="grid">
       <a class="tile" href="/about.html">
@@ -55,6 +83,12 @@
     <script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
     <iframe src="https://subscribe-forms.beehiiv.com/7e97f2c9-aee6-4586-9d07-0ca2538b53ad"
       class="beehiiv-embed" data-test-id="beehiiv-embed" frameborder="0" scrolling="no"></iframe>
+  </section>
+  <section class="about-section">
+    <div class="cta-strip cta-links">
+      <a href="/roadmap.html">View the Roadmap</a>
+      <a href="/waitlist.html">Join the Waitlist</a>
+    </div>
   </section>
 </main>
 <footer>

--- a/waitlist.html
+++ b/waitlist.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <!-- Google tag (gtag.js) -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-NE4XVX952Z"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag(){dataLayer.push(arguments);}
+    gtag('js', new Date());
+
+    gtag('config', 'G-NE4XVX952Z');
+  </script>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Join the Heirloom Waitlist</title>
+  <meta name="description" content="Sign up to join the Heirloom waitlist and get early updates.">
+  <link rel="canonical" href="https://www.tryheirloomai.com/waitlist">
+  <meta property="og:title" content="Join the Heirloom Waitlist">
+  <meta property="og:description" content="Sign up to join the Heirloom waitlist and get early updates.">
+  <meta property="og:image" content="/assets/hero.jpg">
+  <meta name="twitter:card" content="summary_large_image">
+  <link rel="icon" href="/assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="/css/styles.css">
+  <script defer src="/js/main.js"></script>
+</head>
+<body>
+<header>
+  <div class="header-inner">
+    <a href="/" class="logo"><img src="/assets/logo.svg" alt="Heirloom logo"></a>
+    <button class="nav-toggle" aria-label="Menu">☰</button>
+    <nav>
+      <button class="ghost" data-theme-toggle aria-label="Toggle dark mode">🌓</button>
+    </nav>
+  </div>
+</header>
+<main>
+  <section class="about-hero">
+    <h1>Join the Waitlist</h1>
+    <p>Sign up to receive updates and early access.</p>
+  </section>
+  <section id="waitlist">
+    <script async src="https://subscribe-forms.beehiiv.com/embed.js"></script>
+    <iframe src="https://subscribe-forms.beehiiv.com/7e97f2c9-aee6-4586-9d07-0ca2538b53ad" class="beehiiv-embed" data-test-id="beehiiv-embed" frameborder="0" scrolling="no"></iframe>
+  </section>
+  <section class="about-section">
+    <div class="cta-strip cta-links">
+      <a href="/roadmap.html">View the Roadmap</a>
+      <a href="/waitlist.html">Join the Waitlist</a>
+    </div>
+  </section>
+</main>
+<footer>
+  <p>© Heirloom</p>
+  <nav>
+    <a href="/roadmap.html">Roadmap</a> •
+    <a href="/privacy.html">Privacy</a> •
+    <a href="/contact.html">Contact</a>
+  </nav>
+</footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace About page with new multi-section copy and SEO metadata
- add reusable homepage hero + four pillar block and CTA rows
- stub waitlist page and document file locations

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c4b742f920832eadff76708c7c613d